### PR TITLE
docs: Fix typos and clarify statements

### DIFF
--- a/src/Lazy/compact.ts
+++ b/src/Lazy/compact.ts
@@ -4,7 +4,7 @@ import { isAsyncIterable, isIterable, isNotNullable } from "../_internal/utils";
 import filter from "./filter";
 
 /**
- * Returns Iterable/AsyncIterable with all `null` `undefined` values removed.
+ * Returns Iterable/AsyncIterable with all `null` and `undefined` values removed.
  *
  * @example
  * ```ts

--- a/src/Lazy/zip.ts
+++ b/src/Lazy/zip.ts
@@ -54,8 +54,8 @@ function async(
 }
 
 /**
- * Merges together the values of each of the arrays with the values at the corresponding position.
- * Useful when you have separate data sources that are coordinated through matching array indexes.
+ * Merges the values of each of the arrays with the values at the corresponding position together.
+ * Useful when you have separate data sources that are coordinated through matching array indices.
  *
  * @example
  * ```ts

--- a/src/countBy.ts
+++ b/src/countBy.ts
@@ -13,7 +13,7 @@ function incSel<B extends Key>(parent: { [K in B]: number }, k: B) {
 /**
  * Returns a count for the number of objects in each group.
  * Similar to groupBy, but instead of returning a list of values,
- * returns a count for the number of values in that group.
+ * it returns a count for the number of values in that group.
  *
  * @example
  * ```ts

--- a/src/head.ts
+++ b/src/head.ts
@@ -14,7 +14,7 @@ type HeadReturnType<T> = T extends readonly [a: infer H, ...rest: any[]]
   : never;
 
 /**
- * Returns the first element of Iterable/AsyncIterable
+ * Returns the first element of Iterable/AsyncIterable.
  *
  * @example
  * ```ts

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -1,5 +1,5 @@
 /**
- * Returns the same value the is used as the argument.
+ * Returns the same value as the given argument.
  *
  * @example
  * ```ts

--- a/src/partition.ts
+++ b/src/partition.ts
@@ -6,7 +6,7 @@ import { AsyncFunctionException } from "./_internal/error";
 
 /**
  * Split Iterable/AsyncIterable into two arrays:
- * one whose elements all satisfy `f` and one whose elements all do not satisfy `f`.
+ * one with all elements which satisfies `f` and the other with all elements that does not.
  *
  * @example
  * ```ts

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -5,7 +5,7 @@ import ReturnPipeType from "./types/ReturnPipeType";
 
 /**
  * Performs left to right function composition.
- * The first argument have any value; the remaining arguments must be unary.
+ * The first argument can have any value; the remaining arguments must be unary.
  *
  * @example
  * ```ts

--- a/src/tap.ts
+++ b/src/tap.ts
@@ -1,6 +1,6 @@
 /**
  * This method invokes interceptor and returns a value.
- * The interceptor is invoked with one argument
+ * The interceptor is invoked with one argument.
  *
  * @example
  * ```ts

--- a/website/docs_md/getting-started.md
+++ b/website/docs_md/getting-started.md
@@ -58,11 +58,11 @@ const { filter, map, pipe, range, reduce } = require("@fxts/core");
 const take = require("@fxts/core/Lazy/take").default;
 ```
 
-**Note: `esm5` and `cjs` submodules were built with es5 targets, but also not include polyfill.**
+**Note: `esm5` and `cjs` submodules were built targeting `es5`, and also does not include polyfill.**
 
 ### CDN
 
-This script was built with an es5 target and contains polyfill.
+This script was built targeting `es5` and contains polyfill.
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@fxts/core@0.1.4/dist/fx.min.js"></script>

--- a/website/docs_md/overview.md
+++ b/website/docs_md/overview.md
@@ -9,7 +9,7 @@ id: overview
 FxTS is a library for functional programming using iterable/asyncIterable.
 It provides users to write more declarative code, as well as to handle asynchronous data and functions.
 
-to build the above, we have many features such as:
+To build the above, we have many features such as:
 
 - Lazy evaluation
   - It is a useful way to represent large or possibly infinite enumerable data.
@@ -45,7 +45,7 @@ Even if you do `filter` after `map`, it doesn't matter. 2 items are extracted, (
 ### Function composition
 
 Combinations of `Lazy` functions don't evaluate actual values like [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator).
-It can be evaluate with a Strict(`toArray`) or [for-of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of), [await for-of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of). Strict functions can be found [here](https://fxts.dev/docs/index#strict)
+It can be evaluated with a Strict(`toArray`) or [for-of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of), [await for-of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of). Strict functions can be found [here](https://fxts.dev/docs/index#strict)
 
 ```ts
 import { pipe, range, map, filter, take, toArray } from "@fxts/core";


### PR DESCRIPTION
Fixes #

- 문서의 표현을 조금 더 명확하게 수정해 봤습니다. 확인 해 주시면 감사하겠습니다 :)
- 문서 내용 중 truth test 라는 단어가 자주 보이는데, 혹시 predicate로 바꿔보면 어떨까 싶습니다!


- 감사합니다 :)