### PR TITLE
feat: add type predicate overloading of 'filter' function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 💬 [Join the FxTS Slack community(en)](https://join.slack.com/t/fx-ts-en/shared_invite/zt-z3heqgyc-al69EU_l95xnjeMRfvdoMA)
 💬 [Join the FxTS Slack community(ko)](https://join.slack.com/t/fx-ts/shared_invite/zt-yw1x81zq-pNa8nM40X6mQAsu2L4m1Fw)
 
-
 # ![fxts-icon](https://user-images.githubusercontent.com/10924072/141757649-cc715e62-21bb-441d-aeae-4732154ded10.png) FxTS
 
 FxTS is a functional library for TypeScript/JavaScript programmers.

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
       "prettier --write",
       "git add"
     ],
-    "*.json": [
+    "*.(json|md)": [
       "prettier --write",
       "git add"
     ]

--- a/src/Lazy/filter.ts
+++ b/src/Lazy/filter.ts
@@ -218,6 +218,11 @@ function filter<A>(
   iterable: Iterable<A>,
 ): IterableIterator<TruthyTypesOf<A>>;
 
+function filter<A, B extends A>(
+  f: (a: A) => a is B,
+  iterable: Iterable<A>,
+): IterableIterator<B>;
+
 function filter<A, B = unknown>(
   f: (a: A) => B,
   iterable: Iterable<A>,
@@ -227,6 +232,11 @@ function filter<A>(
   f: BooleanConstructor,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<TruthyTypesOf<A>>;
+
+function filter<A, B extends A>(
+  f: (a: A) => a is B,
+  iterable: AsyncIterable<A>,
+): AsyncIterableIterator<B>;
 
 function filter<A, B = unknown>(
   f: (a: A) => B,
@@ -238,6 +248,13 @@ function filter<A extends Iterable<unknown> | AsyncIterable<unknown>>(
 ): (
   iterable: A,
 ) => ReturnIterableIteratorType<A, TruthyTypesOf<IterableInfer<A>>>;
+
+function filter<
+  A extends Iterable<unknown> | AsyncIterable<unknown>,
+  B extends IterableInfer<A>,
+>(
+  f: (a: IterableInfer<A>) => a is B,
+): (iterable: A) => ReturnIterableIteratorType<A, B>;
 
 function filter<
   A extends Iterable<unknown> | AsyncIterable<unknown>,

--- a/src/Lazy/uniqBy.ts
+++ b/src/Lazy/uniqBy.ts
@@ -92,14 +92,14 @@ function uniqBy<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
 
   if (isIterable(iterable)) {
     return pipe(
-      iterable as Iterable<IterableInfer<A>>,
+      iterable,
       filter((a) => pipe1(f(a), checkAndAdd)),
     ) as IterableIterator<A>;
   }
 
   if (isAsyncIterable(iterable)) {
     return pipe(
-      iterable as AsyncIterable<IterableInfer<A>>,
+      iterable,
       filter((a) => pipe1(f(a), checkAndAdd)),
     ) as AsyncIterableIterator<A>;
   }

--- a/type-check/Lazy/filter.test.ts
+++ b/type-check/Lazy/filter.test.ts
@@ -1,5 +1,5 @@
 import * as Test from "../../src/types/Test";
-import { toAsync, filter, pipe } from "../../src";
+import { toAsync, filter, pipe, isString } from "../../src";
 
 const { checks, check } = Test;
 
@@ -7,51 +7,59 @@ const res1 = filter((a) => a % 2 === 0, []);
 const res2 = filter((a) => a % 2 === 0, [1, 2, 3]);
 const res3 = filter(async (a) => a % 2 === 0, [1, 2, 3]);
 const res4 = filter(Boolean, [undefined, null, 0, "", false, -0, 123] as const);
-const res5 = filter((a) => a % 2 === 0, toAsync([1, 2, 3]));
-const res6 = filter(async (a) => a % 2 === 0, toAsync([1, 2, 3]));
-const res7 = filter(
+const res5 = filter(isString, [1, "a", true]);
+const res6 = filter((a) => a % 2 === 0, toAsync([1, 2, 3]));
+const res7 = filter(async (a) => a % 2 === 0, toAsync([1, 2, 3]));
+const res8 = filter(
   Boolean,
   toAsync([undefined, null, 0, "", false, -0, 123] as const),
 );
+const res9 = filter(isString, toAsync([1, "a", true]));
 
-const res8 = pipe(
+const res10 = pipe(
   [1, 2, 3, 4],
   filter((a) => a % 2 === 0),
 );
-const res9 = pipe(
+const res11 = pipe(
   [1, 2, 3, 4],
   filter(async (a) => a % 2 === 0),
 );
-const res10 = pipe(
+const res12 = pipe(
   [undefined, null, 0, "", false, -0, 123] as const,
   filter(Boolean),
 );
-const res11 = pipe(
+const res13 = pipe([1, "a", true], filter(isString));
+const res14 = pipe(
   toAsync([1, 2, 3, 4]),
   filter((a) => a % 2 === 0),
 );
-const res12 = pipe(
+const res15 = pipe(
   toAsync([1, 2, 3, 4]),
   filter(async (a) => a % 2 === 0),
 );
-const res13 = pipe(
+const res16 = pipe(
   toAsync([undefined, null, 0, "", false, -0, 123] as const),
   filter(Boolean),
 );
+const res17 = pipe(toAsync([1, "a", true]), filter(isString));
 
 checks([
   check<typeof res1, IterableIterator<never>, Test.Pass>(),
   check<typeof res2, IterableIterator<number>, Test.Pass>(),
   check<typeof res3, IterableIterator<number>, Test.Pass>(),
   check<typeof res4, IterableIterator<123>, Test.Pass>(),
-  check<typeof res5, AsyncIterableIterator<number>, Test.Pass>(),
+  check<typeof res5, IterableIterator<string>, Test.Pass>(),
   check<typeof res6, AsyncIterableIterator<number>, Test.Pass>(),
-  check<typeof res7, AsyncIterableIterator<123>, Test.Pass>(),
+  check<typeof res7, AsyncIterableIterator<number>, Test.Pass>(),
+  check<typeof res8, AsyncIterableIterator<123>, Test.Pass>(),
+  check<typeof res9, AsyncIterableIterator<string>, Test.Pass>(),
 
-  check<typeof res8, IterableIterator<number>, Test.Pass>(),
-  check<typeof res9, IterableIterator<number>, Test.Pass>(),
-  check<typeof res10, IterableIterator<123>, Test.Pass>(),
-  check<typeof res11, AsyncIterableIterator<number>, Test.Pass>(),
-  check<typeof res12, AsyncIterableIterator<number>, Test.Pass>(),
-  check<typeof res13, AsyncIterableIterator<123>, Test.Pass>(),
+  check<typeof res10, IterableIterator<number>, Test.Pass>(),
+  check<typeof res11, IterableIterator<number>, Test.Pass>(),
+  check<typeof res12, IterableIterator<123>, Test.Pass>(),
+  check<typeof res13, IterableIterator<string>, Test.Pass>(),
+  check<typeof res14, AsyncIterableIterator<number>, Test.Pass>(),
+  check<typeof res15, AsyncIterableIterator<number>, Test.Pass>(),
+  check<typeof res16, AsyncIterableIterator<123>, Test.Pass>(),
+  check<typeof res17, AsyncIterableIterator<string>, Test.Pass>(),
 ]);


### PR DESCRIPTION
To make `type predicate` work as expected in filter function.
I forgot to add this one in previous PR 😄 

```ts

declare function isString(s: unknown): s is string;

const res5 = filter(isString, [1, "a", true]); // IterableIterator<string>
```