### PR TITLE
fix: pass missing 'concurrent' as parameter to async-iterable's 'next

### DIFF
--- a/src/Lazy/filter.ts
+++ b/src/Lazy/filter.ts
@@ -108,8 +108,8 @@ function toFilterIterator<A>(
     [Symbol.asyncIterator]() {
       return this;
     },
-    async next() {
-      const { done, value } = await iterator.next();
+    async next(_concurrent) {
+      const { done, value } = await iterator.next(_concurrent);
       if (done) {
         return {
           done: true,

--- a/src/Lazy/map.ts
+++ b/src/Lazy/map.ts
@@ -37,7 +37,7 @@ function sync<A, B>(
   };
 }
 
-function asyncSequential<A, B>(
+function async<A, B>(
   f: (a: A) => B,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<B> {
@@ -51,26 +51,6 @@ function asyncSequential<A, B>(
         done: false,
         value: await f(value),
       };
-    },
-    [Symbol.asyncIterator]() {
-      return this;
-    },
-  };
-}
-
-function async<A, B>(
-  f: (a: A) => B,
-  iterable: AsyncIterable<A>,
-): AsyncIterableIterator<B> {
-  let _iterator: AsyncIterator<B>;
-  return {
-    async next(_concurrent: any) {
-      if (_iterator === undefined) {
-        _iterator = isConcurrent(_concurrent)
-          ? asyncSequential(f, concurrent(_concurrent.length, iterable))
-          : asyncSequential(f, iterable);
-      }
-      return _iterator.next(_concurrent);
     },
     [Symbol.asyncIterator]() {
       return this;

--- a/src/Lazy/zip.ts
+++ b/src/Lazy/zip.ts
@@ -33,10 +33,10 @@ function async(
     [Symbol.asyncIterator]() {
       return this;
     },
-    async next() {
+    async next(_concurrent) {
       const headIterators = await pipe(
         toAsync(iterators),
-        map((it) => it.next()),
+        map((it) => it.next(_concurrent)),
         toArray,
       );
 

--- a/test/Lazy/append.spec.ts
+++ b/test/Lazy/append.spec.ts
@@ -8,7 +8,8 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
-import { callFuncAfterTime } from "../utils";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { callFuncAfterTime, generatorMock } from "../utils";
 
 describe("append", function () {
   describe("sync", function () {
@@ -83,5 +84,14 @@ describe("append", function () {
       expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
     }, 1050);
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = append(1, mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
+    });
   });
 });

--- a/test/Lazy/chunk.spec.ts
+++ b/test/Lazy/chunk.spec.ts
@@ -9,7 +9,8 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
-import { callFuncAfterTime } from "../utils";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { callFuncAfterTime, generatorMock } from "../utils";
 
 const expected = [
   [1, 2, 3],
@@ -138,6 +139,15 @@ describe("chunk", function () {
     it("should be able to be used as a curried function in the pipeline", async function () {
       const res = await pipe(range(1, 12), toAsync, chunk(3), toArray);
       expect(res).toEqual(expected);
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = chunk(3, mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/Lazy/compact.spec.ts
+++ b/test/Lazy/compact.spec.ts
@@ -1,4 +1,6 @@
 import { compact, filter, map, pipe, toArray, toAsync } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { generatorMock } from "../utils";
 
 describe("compact", function () {
   describe("sync", function () {
@@ -58,6 +60,15 @@ describe("compact", function () {
       );
 
       expect(res).toEqual([14, 18]);
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = compact(mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/Lazy/concat.spec.ts
+++ b/test/Lazy/concat.spec.ts
@@ -7,7 +7,8 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
-import { callFuncAfterTime } from "../utils";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { callFuncAfterTime, generatorMock } from "../utils";
 
 describe("concat", function () {
   describe("sync", function () {
@@ -95,6 +96,15 @@ describe("concat", function () {
         toArray,
       );
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = concat(mock, [1, 2, 3]);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/Lazy/concurrent.spec.ts
+++ b/test/Lazy/concurrent.spec.ts
@@ -1,5 +1,6 @@
 import { concurrent, delay, map, pipe, range, toAsync } from "../../src/index";
-import { callFuncAfterTime } from "../utils";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { callFuncAfterTime, generatorMock } from "../utils";
 
 describe("concurrent", function () {
   it("should be consumed 'AsyncIterable' concurrently", async function () {

--- a/test/Lazy/concurrent.spec.ts
+++ b/test/Lazy/concurrent.spec.ts
@@ -1,6 +1,5 @@
 import { concurrent, delay, map, pipe, range, toAsync } from "../../src/index";
-import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { callFuncAfterTime } from "../utils";
 
 describe("concurrent", function () {
   it("should be consumed 'AsyncIterable' concurrently", async function () {

--- a/test/Lazy/drop.spec.ts
+++ b/test/Lazy/drop.spec.ts
@@ -8,8 +8,9 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
 
-import { callFuncAfterTime } from "../utils";
+import { callFuncAfterTime, generatorMock } from "../utils";
 
 describe("drop", function () {
   describe("sync", function () {
@@ -112,6 +113,15 @@ describe("drop", function () {
           toArray,
         ),
       ).rejects.toThrow("err");
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = drop(2, mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/Lazy/filter.spec.ts
+++ b/test/Lazy/filter.spec.ts
@@ -9,8 +9,9 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
 import { AsyncFunctionException } from "../../src/_internal/error";
-import { callFuncAfterTime } from "../utils";
+import { callFuncAfterTime, generatorMock } from "../utils";
 
 const mod = (a: number) => a % 2 === 0;
 const modAsync = async (a: number) => a % 2 === 0;
@@ -308,5 +309,14 @@ describe("filter", function () {
       const { value: v6 } = await iterator.next();
       expect(v6).toEqual(13);
     }, 4050);
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = filter((a) => a, mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
+    });
   });
 });

--- a/test/Lazy/flat.spec.ts
+++ b/test/Lazy/flat.spec.ts
@@ -2,6 +2,7 @@ import {
   chunk,
   concurrent,
   delay,
+  filter,
   flat,
   map,
   pipe,
@@ -9,7 +10,8 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
-import { callFuncAfterTime } from "../utils";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { callFuncAfterTime, generatorMock } from "../utils";
 
 describe("flat", function () {
   describe("sync", function () {
@@ -342,6 +344,15 @@ describe("flat", function () {
           toArray,
         ),
       ).rejects.toThrow("err");
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = flat(mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/Lazy/flat.spec.ts
+++ b/test/Lazy/flat.spec.ts
@@ -2,7 +2,6 @@ import {
   chunk,
   concurrent,
   delay,
-  filter,
   flat,
   map,
   pipe,

--- a/test/Lazy/flatMap.spec.ts
+++ b/test/Lazy/flatMap.spec.ts
@@ -1,4 +1,6 @@
 import { flatMap, map, pipe, toArray, toAsync } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { generatorMock } from "../utils";
 
 describe("flatMap", function () {
   describe("sync", function () {
@@ -44,6 +46,15 @@ describe("flatMap", function () {
       );
 
       expect(res).toEqual(["IT", "IS", "A", "GOOD", "DAY"]);
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = flatMap((a) => a, mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/Lazy/map.spec.ts
+++ b/test/Lazy/map.spec.ts
@@ -1,5 +1,7 @@
 import { map, pipe, range, toArray, toAsync } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
 import { AsyncFunctionException } from "../../src/_internal/error";
+import { generatorMock } from "../utils";
 
 describe("map", function () {
   const add10 = (a: number) => a + 10;
@@ -79,6 +81,15 @@ describe("map", function () {
       );
 
       expect(res).toEqual(["1", "2", "3", "4"]);
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = map((a) => a, mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/Lazy/peek.spec.ts
+++ b/test/Lazy/peek.spec.ts
@@ -1,4 +1,6 @@
 import { map, peek, pipe, toArray, toAsync } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { generatorMock } from "../utils";
 
 describe("peek", function () {
   describe("sync", function () {
@@ -87,6 +89,15 @@ describe("peek", function () {
       ).rejects.toThrow("err");
 
       expect(res).toEqual([11, 12]);
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = peek((a) => a, mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/Lazy/prepend.spec.ts
+++ b/test/Lazy/prepend.spec.ts
@@ -8,7 +8,8 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
-import { callFuncAfterTime } from "../utils";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { callFuncAfterTime, generatorMock } from "../utils";
 
 describe("prepend", function () {
   describe("sync", function () {
@@ -105,5 +106,15 @@ describe("prepend", function () {
       expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
     }, 1050);
+
+    // TODO
+    // it("should be passed concurrent object when job works concurrently", async function () {
+    //   const mock = generatorMock();
+    //   const iter = prepend(5, mock);
+    //   const concurrent = Concurrent.of(2) as any;
+
+    //   await iter.next(concurrent);
+    //   expect((mock as any).getConcurrent()).toEqual(concurrent);
+    // });
   });
 });

--- a/test/Lazy/prepend.spec.ts
+++ b/test/Lazy/prepend.spec.ts
@@ -8,8 +8,7 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
-import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { callFuncAfterTime } from "../utils";
 
 describe("prepend", function () {
   describe("sync", function () {

--- a/test/Lazy/reject.spec.ts
+++ b/test/Lazy/reject.spec.ts
@@ -1,4 +1,6 @@
 import { pipe, range, reject, toArray, toAsync } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { generatorMock } from "../utils";
 
 const mod = (a: number) => a % 2 === 0;
 const modAsync = async (a: number) => a % 2 === 0;
@@ -74,6 +76,15 @@ describe("reject", function () {
       );
 
       expect(res).toEqual([1, 3]);
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = reject((a) => a, mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/Lazy/take.spec.ts
+++ b/test/Lazy/take.spec.ts
@@ -8,6 +8,8 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { generatorMock } from "../utils";
 
 describe("take", function () {
   describe("sync", function () {
@@ -120,5 +122,14 @@ describe("take", function () {
 
       expect(n1 + n2 + n3).toEqual(1 + 2 + 3);
     }, 1050);
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = take(1, mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
+    });
   });
 });

--- a/test/Lazy/takeUntil.spec.ts
+++ b/test/Lazy/takeUntil.spec.ts
@@ -9,7 +9,9 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
 import { AsyncFunctionException } from "../../src/_internal/error";
+import { generatorMock } from "../utils";
 
 describe("takeUntil", function () {
   describe("sync", function () {
@@ -134,5 +136,14 @@ describe("takeUntil", function () {
       );
       expect(res).toEqual([12, 14, 16, 18, 20, 22]);
     }, 850);
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = takeUntil((a) => a, mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
+    });
   });
 });

--- a/test/Lazy/takeWhile.spec.ts
+++ b/test/Lazy/takeWhile.spec.ts
@@ -9,7 +9,9 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
 import { AsyncFunctionException } from "../../src/_internal/error";
+import { generatorMock } from "../utils";
 
 describe("takeWhile", function () {
   describe("sync", function () {
@@ -126,5 +128,14 @@ describe("takeWhile", function () {
 
       expect(res).toEqual([12, 14, 16, 18, 20]);
     }, 650);
+  });
+
+  it("should be passed concurrent object when job works concurrently", async function () {
+    const mock = generatorMock();
+    const iter = takeWhile((a) => a, mock);
+    const concurrent = Concurrent.of(2) as any;
+
+    await iter.next(concurrent);
+    expect((mock as any).getConcurrent()).toEqual(concurrent);
   });
 });

--- a/test/Lazy/uniq.spec.ts
+++ b/test/Lazy/uniq.spec.ts
@@ -1,4 +1,6 @@
 import { filter, map, pipe, toArray, toAsync, uniq } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { generatorMock } from "../utils";
 
 describe("uniq", function () {
   describe("sync", function () {
@@ -49,6 +51,15 @@ describe("uniq", function () {
       );
 
       expect(res).toEqual([12, 14]);
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = uniq(mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/Lazy/uniqBy.spec.ts
+++ b/test/Lazy/uniqBy.spec.ts
@@ -1,4 +1,6 @@
 import { filter, map, pipe, toArray, toAsync, uniqBy } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { generatorMock } from "../utils";
 
 describe("uniqBy", function () {
   describe("sync", function () {
@@ -108,6 +110,15 @@ describe("uniqBy", function () {
       );
 
       expect(res).toEqual([12, 14]);
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = uniqBy((a) => a, mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/Lazy/zip.spec.ts
+++ b/test/Lazy/zip.spec.ts
@@ -7,7 +7,8 @@ import {
   toAsync,
   zip,
 } from "../../src/index";
-import { callFuncAfterTime } from "../utils";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { callFuncAfterTime, generatorMock } from "../utils";
 
 describe("zip", function () {
   describe("sync", function () {
@@ -246,5 +247,14 @@ describe("zip", function () {
         [4, 8],
       ]);
     }, 1050);
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = zip([1, 2, 3], mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
+    });
   });
 });

--- a/test/Lazy/zipWithIndex.spec.ts
+++ b/test/Lazy/zipWithIndex.spec.ts
@@ -1,4 +1,6 @@
 import { concurrent, delay, toAsync, zipWithIndex } from "../../src/index";
+import { Concurrent } from "../../src/Lazy/concurrent";
+import { generatorMock } from "../utils";
 
 describe("zipWithIndex", function () {
   describe("sync", function () {
@@ -42,6 +44,15 @@ describe("zipWithIndex", function () {
       const {value: [i4, v4]} = await iter.next(); // prettier-ignore
       expect(v1 + v2 + v3 + v4).toEqual("abcd");
       expect([i1, i2, i3, i4]).toEqual([0, 1, 2, 3]);
+    });
+
+    it("should be passed concurrent object when job works concurrently", async function () {
+      const mock = generatorMock();
+      const iter = zipWithIndex(mock);
+      const concurrent = Concurrent.of(2) as any;
+
+      await iter.next(concurrent);
+      expect((mock as any).getConcurrent()).toEqual(concurrent);
     });
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,3 +3,23 @@ import Arrow from "../src/types/Arrow";
 export const callFuncAfterTime = (callback: Arrow, time = 1000) => {
   setTimeout(callback, time);
 };
+
+export const generatorMock = (cnt = 10): AsyncIterableIterator<number> => {
+  let concurrent: any;
+
+  return {
+    getConcurrent() {
+      return concurrent;
+    },
+    async next(_concurrent: any) {
+      concurrent = _concurrent;
+      if (--cnt) {
+        return { done: true, value: undefined };
+      }
+      return { done: false, value: null };
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  } as any;
+};


### PR DESCRIPTION
pass missing 'concurrent' as parameter to async-iterable's 'next