### PR TITLE
Adjust 'timeout' number appropriately

### DIFF
--- a/test/Lazy/dropUntil.spec.ts
+++ b/test/Lazy/dropUntil.spec.ts
@@ -90,11 +90,11 @@ describe("dropUntil", function () {
 
     it("should be dropped elements concurrently", async function () {
       const fn = jest.fn();
-      callFuncAfterTime(fn, 300);
+      callFuncAfterTime(fn, 1500);
       const res = await pipe(
         [1, 2, 3, 4, 5, 1, 2],
         toAsync,
-        map((a) => delay(100, a + 10)),
+        map((a) => delay(500, a + 10)),
         filter((a) => a % 2 === 1),
         dropUntil((a) => a > 13),
         concurrent(3),
@@ -102,25 +102,25 @@ describe("dropUntil", function () {
       );
       expect(fn).toBeCalled();
       expect(res).toEqual([11]);
-    }, 350);
+    }, 1550);
 
     it("should be controlled the order when concurrency", async function () {
       const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
+      callFuncAfterTime(fn, 2000);
 
       const res = await pipe(
         toAsync(
           (function* () {
-            yield delay(500, 1);
-            yield delay(400, 2);
-            yield delay(300, 3);
-            yield delay(200, 4);
-            yield delay(100, 5);
-            yield delay(500, 11);
-            yield delay(400, 12);
-            yield delay(300, 13);
-            yield delay(200, 8);
-            yield delay(100, 9);
+            yield delay(1000, 1);
+            yield delay(900, 2);
+            yield delay(800, 3);
+            yield delay(700, 4);
+            yield delay(600, 5);
+            yield delay(1000, 11);
+            yield delay(900, 12);
+            yield delay(800, 13);
+            yield delay(700, 8);
+            yield delay(600, 9);
           })(),
         ),
         dropUntil((a) => a > 12),
@@ -129,7 +129,7 @@ describe("dropUntil", function () {
       );
       expect(fn).toBeCalled();
       expect(res).toEqual([8, 9]);
-    }, 1050);
+    }, 2050);
 
     it("should be able to handle an error when working concurrent", async function () {
       await expect(

--- a/test/Lazy/dropWhile.spec.ts
+++ b/test/Lazy/dropWhile.spec.ts
@@ -93,21 +93,21 @@ describe("dropWhile", function () {
 
     it("should be controlled the order when concurrency", async function () {
       const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
+      callFuncAfterTime(fn, 2000);
 
       const res = await pipe(
         toAsync(
           (function* () {
-            yield delay(500, 1);
-            yield delay(400, 2);
-            yield delay(300, 3);
-            yield delay(200, 4);
-            yield delay(100, 5);
-            yield delay(500, 6);
-            yield delay(400, 7);
-            yield delay(300, 8);
-            yield delay(200, 1);
-            yield delay(100, 10);
+            yield delay(1000, 1);
+            yield delay(900, 2);
+            yield delay(800, 3);
+            yield delay(700, 4);
+            yield delay(600, 5);
+            yield delay(1000, 6);
+            yield delay(900, 7);
+            yield delay(800, 8);
+            yield delay(700, 1);
+            yield delay(600, 10);
           })(),
         ),
         dropWhile((a) => a < 7),
@@ -116,7 +116,7 @@ describe("dropWhile", function () {
       );
       expect(fn).toBeCalled();
       expect(res).toEqual([7, 8, 1, 10]);
-    }, 1050);
+    }, 2050);
 
     it("should be able to handle an error when working concurrent", async function () {
       await expect(

--- a/test/Lazy/filter.spec.ts
+++ b/test/Lazy/filter.spec.ts
@@ -194,11 +194,11 @@ describe("filter", function () {
 
     it("should be filtered by the callback 'filter' - 'take' - 'concurrent'", async function () {
       const fn = jest.fn();
-      callFuncAfterTime(fn, 2000);
+      callFuncAfterTime(fn, 1000);
 
       const res = await pipe(
         toAsync(range(1, 51)),
-        filter((a) => delay(1000, a % 2 === 0)),
+        filter((a) => delay(500, a % 2 === 0)),
         take(10),
         concurrent(10),
         toArray,
@@ -206,15 +206,15 @@ describe("filter", function () {
 
       expect(fn).toBeCalled();
       expect(res).toEqual([2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
-    }, 2050);
+    }, 1050);
 
     it("should be filtered by the callback 'map' - 'filter' - 'concurrent'", async function () {
       const fn = jest.fn();
-      callFuncAfterTime(fn, 2000);
+      callFuncAfterTime(fn, 1000);
 
       const res = await pipe(
         toAsync(range(1, 21)),
-        map((a) => delay(1000, a + 10)),
+        map((a) => delay(500, a + 10)),
         filter((a) => a % 2 === 0),
         concurrent(10),
         toArray,
@@ -222,15 +222,15 @@ describe("filter", function () {
 
       expect(fn).toBeCalled();
       expect(res).toEqual([12, 14, 16, 18, 20, 22, 24, 26, 28, 30]);
-    }, 2050);
+    }, 1050);
 
     it("should be filtered by the callback 'map' - 'filter' - 'concurrent' - 'take'", async function () {
       const fn = jest.fn();
-      callFuncAfterTime(fn, 200);
+      callFuncAfterTime(fn, 1000);
 
       const res = await pipe(
         toAsync(range(1, 10)),
-        map((a) => delay(100, a)),
+        map((a) => delay(500, a)),
         filter((a) => a),
         concurrent(5),
         take(8),
@@ -239,13 +239,13 @@ describe("filter", function () {
 
       expect(fn).toBeCalled();
       expect(res).toEqual([...range(1, 9)]);
-    }, 210);
+    }, 1050);
 
     it("should be able to handle an error when the callback is asynchronous", async function () {
       await expect(
         pipe(
           toAsync(range(1, 1000)),
-          map((a) => delay(100, a + 10)),
+          map((a) => delay(500, a + 10)),
           filter((a) => {
             if (a === 14) {
               throw new Error("err");
@@ -256,7 +256,7 @@ describe("filter", function () {
           toArray,
         ),
       ).rejects.toThrow("err");
-    }, 250);
+    }, 1050);
 
     it("should be able to handle errors when the callback is asynchronous", async function () {
       await expect(
@@ -285,11 +285,11 @@ describe("filter", function () {
 
     it("should be consumed 'AsyncIterable' as many times as called with 'next'", async function () {
       const fn = jest.fn();
-      callFuncAfterTime(fn, 4000);
+      callFuncAfterTime(fn, 2000);
       const iterator = toAsync(range(1, 21));
       const res = pipe(
         iterator,
-        map((a) => delay(1000, a)),
+        map((a) => delay(500, a)),
         filter((a) => a % 2 === 0),
         concurrent(3),
       );
@@ -308,7 +308,7 @@ describe("filter", function () {
 
       const { value: v6 } = await iterator.next();
       expect(v6).toEqual(13);
-    }, 4050);
+    }, 2050);
 
     it("should be passed concurrent object when job works concurrently", async function () {
       const mock = generatorMock();

--- a/test/Lazy/flat.spec.ts
+++ b/test/Lazy/flat.spec.ts
@@ -66,7 +66,7 @@ describe("flat", function () {
 
     it("should be flattened concurrently", async function () {
       const fn = jest.fn();
-      callFuncAfterTime(fn, 2000);
+      callFuncAfterTime(fn, 1000);
       const iterator = toAsync([
         [1],
         [2],
@@ -82,7 +82,7 @@ describe("flat", function () {
 
       const res = pipe(
         iterator,
-        map((a) => delay(1000, a)),
+        map((a) => delay(500, a)),
         flat,
         concurrent(3),
       );
@@ -103,7 +103,7 @@ describe("flat", function () {
 
       const { value: v7 } = await iterator.next();
       expect(v7).toEqual([13]);
-    }, 2050);
+    }, 1050);
 
     type FlatTest = {
       input: Array<any>;
@@ -123,7 +123,7 @@ describe("flat", function () {
         ],
         depth: 1,
         size: 1,
-        timeout: 2000,
+        timeout: 1000,
         expected: [1, 2, 3, 4, 5, 6, 7, 8],
       },
       {
@@ -135,7 +135,7 @@ describe("flat", function () {
         ],
         depth: 1,
         size: 3,
-        timeout: 2000,
+        timeout: 1000,
         expected: [1, 2, 3, 4, 5, 6, 7, 8],
       },
       {
@@ -147,7 +147,7 @@ describe("flat", function () {
         ],
         depth: 1,
         size: 4,
-        timeout: 1000,
+        timeout: 500,
         expected: [1, 2, 3, 4, 5, 6, 7, 8],
       },
       {
@@ -159,7 +159,7 @@ describe("flat", function () {
         ],
         depth: 1,
         size: 4,
-        timeout: 1000,
+        timeout: 500,
         expected: [1, [2], 3, [4], 5, [6], 7, [8]],
       },
       {
@@ -171,94 +171,54 @@ describe("flat", function () {
         ],
         depth: 2,
         size: 4,
-        timeout: 1000,
+        timeout: 500,
         expected: [1, 2, 3, 4, 5, 6, 7, 8],
       },
       {
-        input: [
-          [1], //
-          [2, 3],
-          [4],
-          [5, 6],
-          [7],
-          [8, 9],
-        ],
+        input: [[1], [2, 3], [4], [5, 6], [7], [8, 9]],
         depth: 1,
         size: 2,
-        timeout: 3000,
+        timeout: 1500,
         expected: [1, 2, 3, 4, 5, 6, 7, 8, 9],
       },
       {
-        input: [
-          [1], //
-          [2, 3],
-          [4],
-          [5, 6],
-          [7],
-          [8, 9],
-          [10],
-        ],
+        input: [[1], [2, 3], [4], [5, 6], [7], [8, 9], [10]],
         depth: 1,
         size: 2,
-        timeout: 4000,
+        timeout: 2000,
         expected: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
       },
       {
-        input: [
-          [1], //
-          [2, 3],
-          [4],
-          [5, 6],
-          [7],
-          [8, 9],
-        ],
+        input: [[1], [2, 3], [4], [5, 6], [7], [8, 9]],
         depth: 1,
         size: 3,
-        timeout: 2000,
+        timeout: 1000,
         expected: [1, 2, 3, 4, 5, 6, 7, 8, 9],
       },
       {
-        input: [
-          [1], //
-          [2, 3, 4],
-          [5, 6],
-          [7, 8, 9, 10],
-          [11, 12],
-        ],
+        input: [[1], [2, 3, 4], [5, 6], [7, 8, 9, 10], [11, 12]],
         depth: 1,
         size: 3,
-        timeout: 2000,
+        timeout: 1000,
         expected: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
       },
       {
-        input: [
-          [1], //
-          [2, 3, 4],
-          [5, 6],
-          [7, 8, 9, 10],
-          [11, 12],
-        ],
+        input: [[1], [2, 3, 4], [5, 6], [7, 8, 9, 10], [11, 12]],
         depth: 1,
         size: 3,
-        timeout: 2000,
+        timeout: 1000,
         expected: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
       },
       {
-        input: [
-          [1], //
-          [[[2]], 3, 4],
-          [5, [[[6]]]],
-          [7, 8, 9, 10],
-          [11, 12],
-        ],
+        input: [[1], [[[2]], 3, 4], [5, [[[6]]]], [7, 8, 9, 10], [11, 12]],
         depth: 2,
         size: 3,
-        timeout: 2000,
+        timeout: 1000,
         expected: [1, [2], 3, 4, 5, [[6]], 7, 8, 9, 10, 11, 12],
       },
       {
         input: [
-          [1], //
+          [1],
           [[[2]], 3, [[[[4]]]]],
           [5, [[[6]]]],
           [7, 8, 9, 10],
@@ -266,13 +226,13 @@ describe("flat", function () {
         ],
         depth: 2,
         size: 5,
-        timeout: 1000,
+        timeout: 500,
         expected: [1, [2], 3, [[[4]]], 5, [[6]], 7, 8, 9, 10, 11, 12],
       },
     ];
 
     it.each(testParameters)(
-      `should be flattened concurrently`,
+      "should be flattened concurrently",
       async ({ timeout, input, depth, size, expected }: FlatTest) => {
         const fn = jest.fn();
         jest.setTimeout(timeout + 100);
@@ -280,7 +240,7 @@ describe("flat", function () {
 
         const res = await pipe(
           toAsync(input),
-          map((a) => delay(1000, a)),
+          map((a) => delay(500, a)),
           (a) => flat(a, depth),
           concurrent(size),
           toArray,
@@ -293,11 +253,11 @@ describe("flat", function () {
 
     it("should be flattened concurrently with chuck", async function () {
       const fn = jest.fn();
-      callFuncAfterTime(fn, 2000);
+      callFuncAfterTime(fn, 1000);
 
       const res = await pipe(
         toAsync(range(1, 7)),
-        map((a) => delay(1000, a)),
+        map((a) => delay(500, a)),
         chunk(2),
         flat,
         concurrent(3),
@@ -306,7 +266,7 @@ describe("flat", function () {
 
       expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
-    }, 2050);
+    }, 1050);
 
     it("should be flattened concurrently with filter", async function () {
       const res = await pipe(


### PR DESCRIPTION
Our tests fail intermittently. https://github.com/marpple/FxTS/pull/39

There are 'timeout' related issues with `jest`, which may not be ours.

https://github.com/facebook/jest/issues?q=is%3Aissue+is%3Aopen+timeout+

If the problem continues, we need to look into it.