### PR TITLE
fix: every type

### DIFF
--- a/src/every.ts
+++ b/src/every.ts
@@ -23,7 +23,7 @@ import Arrow from "./types/Arrow";
  * {@link https://codesandbox.io/s/fxts-every-g91dh | Try It}
  */
 
-function every<A extends readonly []>(f: Arrow, iterable: A): false;
+function every<A extends readonly []>(f: Arrow, iterable: A): true;
 
 // prettier-ignore
 function every<A, B = unknown>(
@@ -59,6 +59,7 @@ function every<
       map(f, iterable as Iterable<IterableInfer<A>>),
       takeUntil(not),
       reduce((a, b) => a && b),
+      (a) => a ?? true,
       Boolean,
     );
   }
@@ -68,6 +69,7 @@ function every<
       map(f, iterable as AsyncIterable<IterableInfer<A>>),
       takeUntil(not),
       reduce((a, b) => a && b),
+      (a) => a ?? true,
       Boolean,
     );
   }

--- a/test/every.spec.ts
+++ b/test/every.spec.ts
@@ -3,11 +3,8 @@ import { AsyncFunctionException } from "../src/_internal/error";
 
 describe("every", function () {
   describe("sync", function () {
-    it("should return 'false' if given 'Iterable' is an empty array", function () {
-      expect(every((a) => a, [])).toEqual(false);
-    });
-
     it.each([
+      [(a: number) => a % 2 === 0, [], true],
       [(a: number) => a % 2 === 0, [2, 4, 6, 8, 10], true],
       [(a: number) => a % 2 === 0, [1, 4, 6, 8, 10], false],
       [(a: number) => a % 2 === 0, [2, 4, 7, 8, 10], false],

--- a/type-check/every.test.ts
+++ b/type-check/every.test.ts
@@ -16,7 +16,7 @@ const res3 = pipe(
 );
 
 checks([
-  check<typeof res0, false, Test.Pass>(),
+  check<typeof res0, true, Test.Pass>(),
   check<typeof res1, boolean, Test.Pass>(),
   check<typeof res2, boolean, Test.Pass>(),
   check<typeof res3, Promise<boolean>, Test.Pass>(),


### PR DESCRIPTION
It seems better to follow [mdn every](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every)

when array is empry, `every` result is true 