### PR TITLE
fix: handle tap async

### DIFF
--- a/src/Lazy/peek.ts
+++ b/src/Lazy/peek.ts
@@ -1,6 +1,7 @@
 import tap from "../tap";
 import map from "./map";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
+import Awaited from "../types/Awaited";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import IterableInfer from "../types/IterableInfer";
 
@@ -63,15 +64,15 @@ function peek<T>(
 ): AsyncIterableIterator<T>;
 
 function peek<T extends Iterable<unknown> | AsyncIterable<unknown>>(
-  f: (a: IterableInfer<T>) => unknown,
+  f: (a: Awaited<IterableInfer<T>>) => unknown,
 ): (iterable: T) => ReturnIterableIteratorType<T>;
 
 function peek<T extends Iterable<unknown> | AsyncIterable<unknown>>(
-  f: (a: IterableInfer<T>) => unknown,
+  f: (a: Awaited<IterableInfer<T>>) => unknown,
   iterable?: T,
 ):
-  | IterableIterator<IterableInfer<T>>
-  | AsyncIterableIterator<IterableInfer<T>>
+  | IterableIterator<Awaited<IterableInfer<T>>>
+  | AsyncIterableIterator<Awaited<IterableInfer<T>>>
   | ((iterable: T) => ReturnIterableIteratorType<T>) {
   if (iterable === undefined) {
     return (iterable: T) => {
@@ -82,15 +83,15 @@ function peek<T extends Iterable<unknown> | AsyncIterable<unknown>>(
   if (isIterable(iterable)) {
     return map(
       tap(f),
-      iterable as Iterable<IterableInfer<T>>,
-    ) as ReturnIterableIteratorType<T, IterableInfer<T>>;
+      iterable as Iterable<Awaited<IterableInfer<T>>>,
+    ) as ReturnIterableIteratorType<T, Awaited<IterableInfer<T>>>;
   }
 
   if (isAsyncIterable(iterable)) {
     return map(
       tap(f),
-      iterable as AsyncIterable<IterableInfer<T>>,
-    ) as ReturnIterableIteratorType<T, IterableInfer<T>>;
+      iterable as AsyncIterable<Awaited<IterableInfer<T>>>,
+    ) as ReturnIterableIteratorType<T, Awaited<IterableInfer<T>>>;
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/tap.ts
+++ b/src/tap.ts
@@ -1,3 +1,4 @@
+import Awaited from "./types/Awaited";
 /**
  * This method invokes interceptor and returns a value.
  * The interceptor is invoked with one argument.
@@ -7,17 +8,40 @@
  * tap(console.log, [1,2,3,4,5])
  * // log [1, 2, 3, 4, 5]
  * // return [1, 2, 3, 4, 5]
+ *
+ * tap(async (a) => console.log(a), [1,2,3,4,5]);
+ * // log [1, 2, 3, 4, 5]
+ * // return Promise<[1, 2, 3, 4, 5]>
  * ```
  */
-function tap<T>(f: (arg: T) => unknown, v: T): T;
+function tap<T, U>(
+  f: (arg: Awaited<T>) => U,
+  v: T,
+): U extends Promise<any> ? Promise<Awaited<T>> : T;
 
-function tap<T>(f: (arg: T) => unknown): (v: T) => T;
+function tap<T, U>(
+  f: (arg: Awaited<T>) => U,
+): (v: T) => U extends Promise<any> ? Promise<Awaited<T>> : T;
 
-function tap<T>(f: (arg: T) => unknown, v?: T): T | ((v: T) => T) {
+function tap<T, U>(
+  f: (arg: Awaited<T>) => U,
+  v?: T,
+):
+  | T
+  | Promise<T>
+  | ((v: T) => U extends Promise<any> ? Promise<Awaited<T>> : T) {
   if (v === undefined) {
-    return (v: T) => (v instanceof Promise ? v.then(f) : f(v), v);
+    return (v: T) =>
+      (v instanceof Promise ? v.then(f) : f(v as Awaited<T>),
+      v) as U extends Promise<any> ? Promise<Awaited<T>> : T;
   }
-  return v instanceof Promise ? v.then(f) : f(v), v;
+
+  const res = v instanceof Promise ? v.then(f) : f(v as Awaited<T>);
+  if (res instanceof Promise) {
+    return res.then(() => v);
+  }
+
+  return v;
 }
 
 export default tap;

--- a/test/tap.spec.ts
+++ b/test/tap.spec.ts
@@ -1,25 +1,38 @@
-import { tap } from "../src/index";
+import { delay, tap } from "../src/index";
+import { callFuncAfterTime } from "./utils";
 
 describe("tap", function () {
-  it("should return the received argument as it is", function () {
-    const res = tap((a) => a * 100, 10);
-    expect(res).toEqual(10);
+  describe("sync", function () {
+    it("should return the received argument as it is", function () {
+      const res = tap((a) => a * 100, 10);
+      expect(res).toEqual(10);
+    });
+
+    it("should invoke the given callback once", function () {
+      const fn = jest.fn((a: number) => a * 100);
+      tap(fn, 10);
+      expect(fn).toBeCalled();
+    });
+
+    it("should be curried when only one function is given as argument", function () {
+      let res1 = 10;
+      const res2 = tap((a: number) => {
+        res1 += a;
+        return res1;
+      })(50);
+
+      expect(res1).toEqual(60);
+      expect(res2).toEqual(50);
+    });
   });
 
-  it("should invoke the given callback once", function () {
-    const fn = jest.fn((a: number) => a * 100);
-    tap(fn, 10);
-    expect(fn).toBeCalled();
-  });
-
-  it("should be curried when only one function is given as argument", function () {
-    let res1 = 10;
-    const res2 = tap((a: number) => {
-      res1 += a;
-      return res1;
-    })(50);
-
-    expect(res1).toEqual(60);
-    expect(res2).toEqual(50);
+  describe("async", function () {
+    it("should return the received argument as it is", async function () {
+      const fn = jest.fn();
+      callFuncAfterTime(fn, 1000);
+      const res = await tap((a) => delay(1000, a), 10);
+      expect(fn).toBeCalled();
+      expect(res).toEqual(10);
+    }, 1050);
   });
 });

--- a/type-check/tap.test.ts
+++ b/type-check/tap.test.ts
@@ -5,13 +5,16 @@ const { checks, check } = Test;
 
 const res1 = tap((a) => a, 123);
 const res2 = tap((a) => Promise.resolve(a), "abc");
-
-const res1Promise = tap((a) => a, Promise.resolve(123));
-const res2Promise = tap((a) => Promise.resolve(a), Promise.resolve("abc"));
+const res3 = tap((a) => a, Promise.resolve(123));
+const res4 = tap((a) => Promise.resolve(a), Promise.resolve("abc"));
+const res5 = tap((a) => (a > 5 ? a : Promise.resolve(a)), Math.random() * 10);
+const res6 = tap((a) => (a > 5 ? a : Promise.resolve(a)), Promise.resolve(Math.random() * 10)); // prettier-ignore
 
 checks([
   check<typeof res1, number, Test.Pass>(),
-  check<typeof res2, string, Test.Pass>(),
-  check<typeof res1Promise, Promise<number>, Test.Pass>(),
-  check<typeof res2Promise, Promise<string>, Test.Pass>(),
+  check<typeof res2, Promise<string>, Test.Pass>(),
+  check<typeof res3, Promise<number>, Test.Pass>(),
+  check<typeof res4, Promise<string>, Test.Pass>(),
+  check<typeof res5, number | Promise<number>, Test.Pass>(),
+  check<typeof res6, Promise<number>, Test.Pass>(),
 ]);


### PR DESCRIPTION
why?

If the auxiliary function of tap is asynchronous, it is more natural to wait and return the original value.
