### PR TITLE
fix: change wrong pattern for test

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require("path");
 
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,8 @@
+const path = require('path');
+
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  testMatch: [path.join(__dirname, "test/**/*.spec.ts")],
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prettier": "npx prettier --config .prettierrc --check .",
     "prettier:fix": "npx prettier --config .prettierrc --write .",
     "release": "npx np --no-tests --no-publish --message 'v%s'",
-    "test": "jest test/*.spec.ts test/**/*.spec.ts",
+    "test": "jest",
     "webpack": "webpack"
   },
   "repository": {


### PR DESCRIPTION
I found tests of FxTs are consist of for type check and for unit test.
But all type check only tests run and are failed when I run `npm test`.

Your test script specified glob pattern of under `/test` directory. But jest does't recognize it.

So, I investigated about it. and I found an issue about this. ([comment](https://github.com/facebook/jest/issues/7108#issuecomment-604905294)). and I referred to the comment and changed your config.
I'm still confused why jest doesn't work with your config. But I guess It's because of micromatch which is used for glob pattern.

BEFORE:
all type check tests are failed
![image](https://user-images.githubusercontent.com/25566139/146244266-4a2405ae-17b5-4581-8ba2-e752f44d4215.png)

AFTER:
all type check tests are not target.
![image](https://user-images.githubusercontent.com/25566139/146244421-a03c5131-99ea-45d7-8633-6d84f5e40f71.png)


ps. Sometimes some tests are failed because they depend on timeout api. I think it'd be nice to fix it. thx 
![image](https://user-images.githubusercontent.com/25566139/146245134-29e0c889-9b97-41fa-8004-45ec9ecc83fe.png)
