### PR TITLE
docs: fix simple typo, inffered -> inferred

### DIFF
--- a/website/docs_md/getting-started.md
+++ b/website/docs_md/getting-started.md
@@ -48,7 +48,7 @@ const sum = pipe(
   map((a) => a * 10),
   take(10),
   reduce((a, b) => a + b),
-); // typeof 'sum' inffered as the number
+); // typeof 'sum' inferred as the number
 ```
 
 **Note: It is recommended to enable [strictFunctionTypes](https://www.typescriptlang.org/tsconfig#strictFunctionTypes) tsc option. If not, type inference does not work as we expected. For example, in the example above, `sum` is not inferred as a number type if the option is turned off.**


### PR DESCRIPTION
There is a small typo in website/docs_md/getting-started.md.

Should read `inferred` rather than `inffered`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md