### PR TITLE
fix: change return type of `isIterable`

### DIFF
--- a/src/Lazy/cycle.ts
+++ b/src/Lazy/cycle.ts
@@ -79,11 +79,11 @@ function cycle<T extends Iterable<unknown> | AsyncIterable<unknown>>(
 ):
   | IterableIterator<IterableInfer<T>>
   | AsyncIterableIterator<IterableInfer<T>> {
-  if (isIterable(iterable)) {
-    return sync(iterable as Iterable<IterableInfer<T>>);
+  if (isIterable<IterableInfer<T>>(iterable)) {
+    return sync(iterable);
   }
-  if (isAsyncIterable(iterable)) {
-    return async(iterable as AsyncIterable<IterableInfer<T>>);
+  if (isAsyncIterable<IterableInfer<T>>(iterable)) {
+    return async(iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/Lazy/drop.ts
+++ b/src/Lazy/drop.ts
@@ -125,12 +125,12 @@ function drop<A extends Iterable<unknown> | AsyncIterable<unknown>>(
     throw new TypeError("'length' must be greater than 1");
   }
 
-  if (isIterable(iterable)) {
-    return sync(length, iterable) as IterableIterator<A>;
+  if (isIterable<A>(iterable)) {
+    return sync(length, iterable);
   }
 
-  if (isAsyncIterable(iterable)) {
-    return async(length, iterable) as AsyncIterableIterator<A>;
+  if (isAsyncIterable<A>(iterable)) {
+    return async(length, iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/Lazy/dropUntil.ts
+++ b/src/Lazy/dropUntil.ts
@@ -136,12 +136,12 @@ function dropUntil<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
     };
   }
 
-  if (isIterable(iterable)) {
-    return sync(f, iterable as Iterable<IterableInfer<A>>);
+  if (isIterable<IterableInfer<A>>(iterable)) {
+    return sync(f, iterable);
   }
 
-  if (isAsyncIterable(iterable)) {
-    return async(f, iterable as AsyncIterable<IterableInfer<A>>);
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
+    return async(f, iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/Lazy/dropWhile.ts
+++ b/src/Lazy/dropWhile.ts
@@ -139,12 +139,12 @@ function dropWhile<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
     };
   }
 
-  if (isIterable(iterable)) {
-    return sync(f, iterable as Iterable<IterableInfer<A>>);
+  if (isIterable<IterableInfer<A>>(iterable)) {
+    return sync(f, iterable);
   }
 
-  if (isAsyncIterable(iterable)) {
-    return async(f, iterable as AsyncIterable<IterableInfer<A>>);
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
+    return async(f, iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/Lazy/filter.ts
+++ b/src/Lazy/filter.ts
@@ -286,12 +286,12 @@ function filter<
       >;
   }
 
-  if (isIterable(iterable)) {
-    return sync(f, iterable as Iterable<IterableInfer<A>>);
+  if (isIterable<IterableInfer<A>>(iterable)) {
+    return sync(f, iterable);
   }
 
-  if (isAsyncIterable(iterable)) {
-    return async(f, iterable as AsyncIterable<IterableInfer<A>>);
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
+    return async(f, iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/Lazy/flatMap.ts
+++ b/src/Lazy/flatMap.ts
@@ -91,14 +91,14 @@ function flatMap<
     };
   }
 
-  if (isIterable(iterable)) {
-    return flat(
-      map(f, iterable as Iterable<IterableInfer<A>>),
-    ) as IterableIterator<DeepFlat<FlatMapValue<B, A>, 1>>;
+  if (isIterable<IterableInfer<A>>(iterable)) {
+    return flat(map(f, iterable)) as IterableIterator<
+      DeepFlat<FlatMapValue<B, A>, 1>
+    >;
   }
 
-  if (isAsyncIterable(iterable)) {
-    return flat(map(f, iterable as AsyncIterable<Awaited<IterableInfer<A>>>));
+  if (isAsyncIterable<Awaited<IterableInfer<A>>>(iterable)) {
+    return flat(map(f, iterable));
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/Lazy/map.ts
+++ b/src/Lazy/map.ts
@@ -132,12 +132,12 @@ function map<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
     };
   }
 
-  if (isIterable(iterable)) {
-    return sync(f, iterable as Iterable<IterableInfer<A>>);
+  if (isIterable<IterableInfer<A>>(iterable)) {
+    return sync(f, iterable);
   }
 
-  if (isAsyncIterable(iterable)) {
-    return async(f, iterable as AsyncIterable<IterableInfer<A>>);
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
+    return async(f, iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/Lazy/peek.ts
+++ b/src/Lazy/peek.ts
@@ -80,18 +80,18 @@ function peek<T extends Iterable<unknown> | AsyncIterable<unknown>>(
     };
   }
 
-  if (isIterable(iterable)) {
-    return map(
-      tap(f),
-      iterable as Iterable<Awaited<IterableInfer<T>>>,
-    ) as ReturnIterableIteratorType<T, Awaited<IterableInfer<T>>>;
+  if (isIterable<Awaited<IterableInfer<T>>>(iterable)) {
+    return map(tap(f), iterable) as ReturnIterableIteratorType<
+      T,
+      Awaited<IterableInfer<T>>
+    >;
   }
 
-  if (isAsyncIterable(iterable)) {
-    return map(
-      tap(f),
-      iterable as AsyncIterable<Awaited<IterableInfer<T>>>,
-    ) as ReturnIterableIteratorType<T, Awaited<IterableInfer<T>>>;
+  if (isAsyncIterable<Awaited<IterableInfer<T>>>(iterable)) {
+    return map(tap(f), iterable) as ReturnIterableIteratorType<
+      T,
+      Awaited<IterableInfer<T>>
+    >;
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/Lazy/reject.ts
+++ b/src/Lazy/reject.ts
@@ -90,18 +90,12 @@ function reject<
     };
   }
 
-  if (isIterable(iterable)) {
-    return filter(
-      (a) => pipe1(f(a), not),
-      iterable as Iterable<IterableInfer<A>>,
-    );
+  if (isIterable<IterableInfer<A>>(iterable)) {
+    return filter((a) => pipe1(f(a), not), iterable);
   }
 
-  if (isAsyncIterable(iterable)) {
-    return filter(
-      (a) => pipe1(f(a), not),
-      iterable as AsyncIterable<IterableInfer<A>>,
-    );
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
+    return filter((a) => pipe1(f(a), not), iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/Lazy/split.ts
+++ b/src/Lazy/split.ts
@@ -120,12 +120,12 @@ function split<A extends Iterable<string> | AsyncIterable<string>>(
     };
   }
 
-  if (isIterable(iterable)) {
-    return sync(sep, iterable as Iterable<string>);
+  if (isIterable<string>(iterable)) {
+    return sync(sep, iterable);
   }
 
-  if (isAsyncIterable(iterable)) {
-    return async(sep, iterable as AsyncIterable<string>);
+  if (isAsyncIterable<string>(iterable)) {
+    return async(sep, iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/Lazy/take.ts
+++ b/src/Lazy/take.ts
@@ -92,12 +92,12 @@ function take<A extends Iterable<unknown> | AsyncIterable<unknown>>(
     };
   }
 
-  if (isIterable(iterable)) {
-    return sync(l, iterable) as IterableIterator<IterableInfer<A>>;
+  if (isIterable<IterableInfer<A>>(iterable)) {
+    return sync(l, iterable);
   }
 
-  if (isAsyncIterable(iterable)) {
-    return async(l, iterable) as AsyncIterableIterator<IterableInfer<A>>;
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
+    return async(l, iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/_internal/utils.ts
+++ b/src/_internal/utils.ts
@@ -2,7 +2,7 @@ import { Iter } from "../types/Utils";
 
 export function isIterable<T = unknown>(
   a: Iter<T> | unknown,
-): a is Iterable<T> | Iterable<Promise<T>> {
+): a is Iterable<T> {
   return typeof (a as any)?.[Symbol.iterator] === "function";
 }
 

--- a/src/average.ts
+++ b/src/average.ts
@@ -26,18 +26,18 @@ function average<T extends Iterable<number> | AsyncIterable<number>>(
 ): ReturnValueType<T> {
   let size = 0;
 
-  if (isIterable(iterable)) {
+  if (isIterable<number>(iterable)) {
     return pipe(
-      iterable as Iterable<number>,
+      iterable,
       peek(() => size++),
       sum,
       (a) => (size === 0 ? NaN : a / size),
     ) as ReturnValueType<T>;
   }
 
-  if (isAsyncIterable(iterable)) {
+  if (isAsyncIterable<number>(iterable)) {
     return pipe(
-      iterable as AsyncIterable<number>,
+      iterable,
       peek(() => size++),
       sum,
       (a) => (size === 0 ? NaN : a / size),

--- a/src/countBy.ts
+++ b/src/countBy.ts
@@ -74,7 +74,7 @@ function countBy<
 
   const obj = {} as { [K in B]: number };
 
-  if (isIterable(iterable)) {
+  if (isIterable<IterableInfer<A>>(iterable)) {
     return reduce(
       (group, a) => {
         const key = f(a);
@@ -84,18 +84,18 @@ function countBy<
         return incSel(group, key);
       },
       obj,
-      iterable as Iterable<IterableInfer<A>>,
+      iterable,
     );
   }
 
-  if (isAsyncIterable(iterable)) {
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
     return reduce(
       async (group, a) => {
         const key = await f(a);
         return incSel(group, key);
       },
       obj,
-      iterable as AsyncIterable<IterableInfer<A>>,
+      iterable,
     );
   }
 

--- a/src/each.ts
+++ b/src/each.ts
@@ -56,12 +56,12 @@ function each<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
     };
   }
 
-  if (isIterable(iterable)) {
-    return sync(f, iterable as Iterable<IterableInfer<A>>);
+  if (isIterable<IterableInfer<A>>(iterable)) {
+    return sync(f, iterable);
   }
 
-  if (isAsyncIterable(iterable)) {
-    return async(f, iterable as AsyncIterable<IterableInfer<A>>);
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
+    return async(f, iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/every.ts
+++ b/src/every.ts
@@ -54,9 +54,9 @@ function every<
     };
   }
 
-  if (isIterable(iterable)) {
+  if (isIterable<IterableInfer<A>>(iterable)) {
     return pipe(
-      map(f, iterable as Iterable<IterableInfer<A>>),
+      map(f, iterable),
       takeUntil(not),
       reduce((a, b) => a && b),
       (a) => a ?? true,
@@ -64,9 +64,9 @@ function every<
     );
   }
 
-  if (isAsyncIterable(iterable)) {
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
     return pipe(
-      map(f, iterable as AsyncIterable<IterableInfer<A>>),
+      map(f, iterable),
       takeUntil(not),
       reduce((a, b) => a && b),
       (a) => a ?? true,

--- a/src/find.ts
+++ b/src/find.ts
@@ -40,11 +40,11 @@ function find<T extends Iterable<unknown> | AsyncIterable<unknown>>(
     return (iterable: T) =>
       find(f, iterable) as ReturnValueType<T, IterableInfer<T> | undefined>;
   }
-  if (isIterable(iterable)) {
-    return head(filter(f, iterable as Iterable<IterableInfer<T>>));
+  if (isIterable<IterableInfer<T>>(iterable)) {
+    return head(filter(f, iterable));
   }
-  if (isAsyncIterable(iterable)) {
-    return head(filter(f, iterable as AsyncIterable<IterableInfer<T>>));
+  if (isAsyncIterable<IterableInfer<T>>(iterable)) {
+    return head(filter(f, iterable));
   }
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");
 }

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -4,6 +4,7 @@ import IterableInfer from "./types/IterableInfer";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 import { AsyncFunctionException } from "./_internal/error";
 import reduce from "./reduce";
+import iterableInfer from "./types/IterableInfer";
 
 /**
  * Splits Iterable/AsyncIterable into sets, grouped by the result of running each value through `f`.
@@ -74,7 +75,7 @@ function groupBy<
   }
 
   const obj = {} as { [K in B]: IterableInfer<A>[] };
-  if (isIterable(iterable)) {
+  if (isIterable<IterableInfer<A>>(iterable)) {
     return reduce(
       (group, a) => {
         const key = f(a);
@@ -84,18 +85,18 @@ function groupBy<
         return (group[key] || (group[key] = [])).push(a), group;
       },
       obj,
-      iterable as Iterable<IterableInfer<A>>,
+      iterable,
     );
   }
 
-  if (isAsyncIterable(iterable)) {
+  if (isAsyncIterable<iterableInfer<A>>(iterable)) {
     return reduce(
       async (group, a) => {
         const key = await f(a);
         return (group[key] || (group[key] = [])).push(a), group;
       },
       obj,
-      iterable as AsyncIterable<IterableInfer<A>>,
+      iterable,
     );
   }
 

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -67,7 +67,7 @@ function indexBy<
   }
 
   const obj = {} as { [K in B]: IterableInfer<A> };
-  if (isIterable(iterable)) {
+  if (isIterable<IterableInfer<A>>(iterable)) {
     return reduce(
       (group, a) => {
         const key = f(a);
@@ -77,18 +77,18 @@ function indexBy<
         return (group[key] = a), group;
       },
       obj,
-      iterable as Iterable<IterableInfer<A>>,
+      iterable,
     );
   }
 
-  if (isAsyncIterable(iterable)) {
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
     return reduce(
       async (group, a) => {
         const key = await f(a);
         return (group[key] = a), group;
       },
       obj,
-      iterable as AsyncIterable<IterableInfer<A>>,
+      iterable,
     );
   }
 

--- a/src/join.ts
+++ b/src/join.ts
@@ -67,11 +67,11 @@ function join<A extends Iterable<unknown> | AsyncIterable<unknown>>(
   if (Array.isArray(iterable) && iterable.length === 0) return "";
 
   if (isIterable(iterable)) {
-    return sync(sep, iterable) as string;
+    return sync(sep, iterable);
   }
 
   if (isAsyncIterable(iterable)) {
-    return async(sep, iterable) as Promise<string>;
+    return async(sep, iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/max.ts
+++ b/src/max.ts
@@ -52,9 +52,9 @@ function max<A extends Iterable<number> | AsyncIterable<number>>(
 
 function max(iterable: Iterable<number> | AsyncIterable<number>) {
   if (isIterable(iterable)) {
-    return sync(iterable as Iterable<number>);
+    return sync(iterable);
   } else if (isAsyncIterable(iterable)) {
-    return async(iterable as AsyncIterable<number>);
+    return async(iterable);
   }
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");
 }

--- a/src/min.ts
+++ b/src/min.ts
@@ -53,9 +53,9 @@ function min<A extends Iterable<number> | AsyncIterable<number>>(
 
 function min(iterable: Iterable<number> | AsyncIterable<number>) {
   if (isIterable(iterable)) {
-    return sync(iterable as Iterable<number>);
+    return sync(iterable);
   } else if (isAsyncIterable(iterable)) {
-    return async(iterable as AsyncIterable<number>);
+    return async(iterable);
   }
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");
 }

--- a/src/nth.ts
+++ b/src/nth.ts
@@ -78,11 +78,11 @@ function nth<T extends Iterable<unknown> | AsyncIterable<unknown>>(
     throw new RangeError("'index' must be over 0");
   }
 
-  if (isIterable(iterable)) {
-    return sync(index, iterable as Iterable<IterableInfer<T>>);
+  if (isIterable<IterableInfer<T>>(iterable)) {
+    return sync(index, iterable);
   }
-  if (isAsyncIterable(iterable)) {
-    return async(index, iterable as AsyncIterable<IterableInfer<T>>);
+  if (isAsyncIterable<IterableInfer<T>>(iterable)) {
+    return async(index, iterable);
   }
 
   throw new TypeError("'iterable' must be type of Iterable or AsyncIterable");

--- a/src/partition.ts
+++ b/src/partition.ts
@@ -66,22 +66,19 @@ function partition<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
     };
   }
 
-  if (isIterable(iterable)) {
+  if (isIterable<IterableInfer<A>>(iterable)) {
     const group = groupBy((a) => {
-      const key = f(a as IterableInfer<A>);
+      const key = f(a);
       if (key instanceof Promise) {
         throw new AsyncFunctionException();
       }
       return `${Boolean(key)}`;
-    }, iterable as Iterable<IterableInfer<A>>);
+    }, iterable);
     return [group["true"] || [], group["false"] || []];
   }
 
-  if (isAsyncIterable(iterable)) {
-    const group = groupBy(
-      async (a) => `${Boolean(await f(a as IterableInfer<A>))}`,
-      iterable as AsyncIterable<IterableInfer<A>>,
-    );
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
+    const group = groupBy(async (a) => `${Boolean(await f(a))}`, iterable);
     return group.then((group) => [group["true"] || [], group["false"] || []]);
   }
 

--- a/src/some.ts
+++ b/src/some.ts
@@ -74,18 +74,18 @@ function some<
     };
   }
 
-  if (isIterable(iterable)) {
+  if (isIterable<IterableInfer<A>>(iterable)) {
     return pipe(
-      map(f, iterable as Iterable<IterableInfer<A>>),
+      map(f, iterable),
       takeUntil(identity),
       reduce((a, b) => a || b),
       Boolean,
     );
   }
 
-  if (isAsyncIterable(iterable)) {
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
     return pipe(
-      map(f, iterable as AsyncIterable<IterableInfer<A>>),
+      map(f, iterable),
       takeUntil(identity),
       reduce((a, b) => a || b),
       Boolean,


### PR DESCRIPTION
very minor change 

change return type of `isIterable` util function for better type inference. 