### PR TITLE
fix: support async tap when curried

### DIFF
--- a/src/tap.ts
+++ b/src/tap.ts
@@ -31,9 +31,7 @@ function tap<T, U>(
   | Promise<T>
   | ((v: T) => U extends Promise<any> ? Promise<Awaited<T>> : T) {
   if (v === undefined) {
-    return (v: T) =>
-      (v instanceof Promise ? v.then(f) : f(v as Awaited<T>),
-      v) as U extends Promise<any> ? Promise<Awaited<T>> : T;
+    return (v: T) => tap(f, v);
   }
 
   const res = v instanceof Promise ? v.then(f) : f(v as Awaited<T>);

--- a/test/tap.spec.ts
+++ b/test/tap.spec.ts
@@ -1,4 +1,4 @@
-import { delay, tap } from "../src/index";
+import { delay, map, pipe, range, tap, toArray, toAsync } from "../src/index";
 import { callFuncAfterTime } from "./utils";
 
 describe("tap", function () {
@@ -34,5 +34,12 @@ describe("tap", function () {
       expect(fn).toBeCalled();
       expect(res).toEqual(10);
     }, 1050);
+
+    it("should support asynchronous when curried.", async function () {
+      const fn = jest.fn();
+      callFuncAfterTime(fn, 500);
+      await pipe(range(5), toAsync, map(tap(() => delay(100))), toArray);
+      expect(fn).toBeCalled();
+    });
   });
 });


### PR DESCRIPTION

It should support asynchronous function when `tap` is curried

