### PR TITLE
chore: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# global
+    @ppeeou @shine1594 @hg-pyun
+
+# source
+/src/ @ppeeou @shine1594K

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
     @ppeeou @shine1594 @hg-pyun
 
 # source
-/src/ @ppeeou @shine1594K
+/src/ @ppeeou @shine1594


### PR DESCRIPTION
Fixes #127 

Add codeowners in `.github` folder.

## Reference
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners