### PR TITLE
feat: add `fromEntries` function

### DIFF
--- a/src/Lazy/entries.ts
+++ b/src/Lazy/entries.ts
@@ -12,6 +12,9 @@ type Entries<T extends Record<string, any>, K extends keyof T> = K extends any
  * [...entries({ a: 1, b: "2", c: true })]
  * // [["a", 1], ["b", "2"], ["c", true]]
  * ```
+ *
+ *
+ * see {@link https://fxts.dev/docs/fromEntries | fromEntries}
  */
 
 function* entries<T extends Record<string, any>>(

--- a/src/fromEntries.ts
+++ b/src/fromEntries.ts
@@ -1,0 +1,67 @@
+import IterableInfer from "./types/IterableInfer";
+import ReturnValueType from "./types/ReturnValueType";
+import { isAsyncIterable, isIterable } from "./_internal/utils";
+
+async function async<T extends [string, any]>(
+  iterable: AsyncIterable<T>,
+): Promise<{
+  [K in T as K[0]]: K[1];
+}> {
+  const a = {} as any;
+  for await (const i of iterable) {
+    a[i[0]] = i[1];
+  }
+  return a;
+}
+
+/**
+ * Returns an object from string keyed-value pairs.
+ *
+ * @example
+ * ```ts
+ * const arr = [
+ *     ["a", 1],
+ *     ["b", true],
+ *     ["c", "hello"],
+ *     ["d", { d1: 1, d2: 3 }],
+ * ] as (
+ *     | ["a", number]
+ *     | ["b", boolean]
+ *     | ["c", string]
+ *     | ["d", { d1: number, d2: number; }]
+ * )[];
+ * fromEntries(arr); // { a: 1, b: true, c: 'hello', d: { d1: 1, d2: 3 } }
+ * ```
+ *
+ *
+ * see {@link https://fxts.dev/docs/entries | entries}
+ */
+
+function fromEntries<
+  U extends [string, any] | readonly [string, any],
+  T extends Iterable<U> | AsyncIterable<U>,
+>(
+  iterable: T,
+): ReturnValueType<
+  T,
+  {
+    [K in IterableInfer<T> as K[0]]: K[1];
+  }
+>;
+function fromEntries<T extends [string, any]>(
+  iter: Iterable<T> | AsyncIterable<T>,
+) {
+  if (isAsyncIterable(iter)) {
+    return async(iter);
+  } else if (isIterable(iter)) {
+    return [...iter].reduce((obj, [key, val]) => {
+      obj[key] = val;
+      return obj;
+    }, {} as any);
+  }
+  return {} as {
+    [K in T as K[0]]: K[1];
+  };
+}
+
+export default fromEntries;

--- a/src/fromEntries.ts
+++ b/src/fromEntries.ts
@@ -1,8 +1,9 @@
 import IterableInfer from "./types/IterableInfer";
+import Key from "./types/Key";
 import ReturnValueType from "./types/ReturnValueType";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
-async function async<T extends [string, any]>(
+async function async<T extends [Key, any]>(
   iterable: AsyncIterable<T>,
 ): Promise<{
   [K in T as K[0]]: K[1];
@@ -38,7 +39,7 @@ async function async<T extends [string, any]>(
  */
 
 function fromEntries<
-  U extends [string, any] | readonly [string, any],
+  U extends [Key, any] | readonly [Key, any],
   T extends Iterable<U> | AsyncIterable<U>,
 >(
   iterable: T,
@@ -48,7 +49,7 @@ function fromEntries<
     [K in IterableInfer<T> as K[0]]: K[1];
   }
 >;
-function fromEntries<T extends [string, any]>(
+function fromEntries<T extends [Key, any]>(
   iter: Iterable<T> | AsyncIterable<T>,
 ) {
   if (isAsyncIterable(iter)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import every from "./every";
 import evolve from "./evolve";
 import find from "./find";
 import findIndex from "./findIndex";
+import fromEntries from "./fromEntries";
 import groupBy from "./groupBy";
 import head from "./head";
 import identity from "./identity";
@@ -59,6 +60,7 @@ export {
   evolve,
   find,
   findIndex,
+  fromEntries,
   groupBy,
   head,
   head as first,

--- a/test/fromEntries.spec.ts
+++ b/test/fromEntries.spec.ts
@@ -1,0 +1,22 @@
+import { fromEntries } from "../src/index";
+
+//an object from string keyed-value pairs.
+describe("fromEntries", function () {
+  describe("sync", function () {
+    it("should return proper object when iterable string keyed-value pairs is given as an argument", function () {
+      const arr = [
+        ["a", 1],
+        ["b", true],
+        ["c", "hello"],
+        ["d", { d1: 1, d2: 3 }],
+      ] as (
+        | ["a", number]
+        | ["b", true]
+        | ["c", string]
+        | ["d", { d1: number; d2: number }]
+      )[];
+      const res = fromEntries(arr);
+      expect(res).toEqual({ a: 1, b: true, c: "hello", d: { d1: 1, d2: 3 } });
+    });
+  });
+});

--- a/test/fromEntries.spec.ts
+++ b/test/fromEntries.spec.ts
@@ -1,4 +1,4 @@
-import { fromEntries } from "../src/index";
+import { fromEntries, toAsync } from "../src/index";
 
 //an object from string keyed-value pairs.
 describe("fromEntries", function () {
@@ -16,6 +16,51 @@ describe("fromEntries", function () {
         | ["d", { d1: number; d2: number }]
       )[];
       const res = fromEntries(arr);
+      expect(res).toEqual({ a: 1, b: true, c: "hello", d: { d1: 1, d2: 3 } });
+    });
+    it("should return proper object when ES6 Map is given as an argument", function () {
+      const sym = Symbol();
+      const sym2 = Symbol();
+      const arr: [
+        string | number | symbol,
+        number | string | { a1: number; b1: string },
+      ][] = [
+        ["a", 1],
+        ["b", "hello"],
+        [10, 1000],
+        [20, 2000],
+        [sym, "symbol"],
+        [sym2, { a1: 100, b1: "hello symbol" }],
+        ["obj", { a1: 10, b1: "hello object" }],
+      ];
+      const map = new Map(arr);
+      const res = fromEntries(map);
+      expect(res).toEqual({
+        10: 1000,
+        20: 2000,
+        a: 1,
+        b: "hello",
+        obj: { a1: 10, b1: "hello object" },
+        [sym]: "symbol",
+        [sym2]: { a1: 100, b1: "hello symbol" },
+      });
+    });
+  });
+
+  describe("async", function () {
+    it("should return proper object when asyncIterable string keyed-value pairs is given as an argument", async function () {
+      const arr = [
+        ["a", 1],
+        ["b", true],
+        ["c", "hello"],
+        ["d", { d1: 1, d2: 3 }],
+      ] as (
+        | ["a", number]
+        | ["b", true]
+        | ["c", string]
+        | ["d", { d1: number; d2: number }]
+      )[];
+      const res = await fromEntries(toAsync(arr));
       expect(res).toEqual({ a: 1, b: true, c: "hello", d: { d1: 1, d2: 3 } });
     });
   });

--- a/type-check/fromEntries.test.ts
+++ b/type-check/fromEntries.test.ts
@@ -1,5 +1,5 @@
 import * as Test from "../src/types/Test";
-import { fromEntries, entries, pipe } from "../src";
+import { fromEntries, entries, pipe, toAsync } from "../src";
 
 const { checks, check } = Test;
 
@@ -24,8 +24,10 @@ const arr = [
 
 const res1 = fromEntries(arr);
 const res2 = pipe(obj, entries, fromEntries);
+const res3 = pipe(obj, entries, toAsync, fromEntries);
 
 checks([
   check<typeof res1, typeof obj, Test.Pass>(),
-  check<typeof res2, typeof res1, Test.Pass>(),
+  check<typeof res2, typeof obj, Test.Pass>(),
+  check<typeof res3, Promise<typeof obj>, Test.Pass>(),
 ]);

--- a/type-check/fromEntries.test.ts
+++ b/type-check/fromEntries.test.ts
@@ -24,10 +24,14 @@ const arr = [
 
 const res1 = fromEntries(arr);
 const res2 = pipe(obj, entries, fromEntries);
-const res3 = pipe(obj, entries, toAsync, fromEntries);
+const res3 = pipe(obj, entries, (iter) => fromEntries(iter));
+const res4 = pipe(obj, entries, toAsync, fromEntries);
+const res5 = pipe(obj, entries, toAsync, (iter) => fromEntries(iter));
 
 checks([
   check<typeof res1, typeof obj, Test.Pass>(),
   check<typeof res2, typeof obj, Test.Pass>(),
-  check<typeof res3, Promise<typeof obj>, Test.Pass>(),
+  check<typeof res3, typeof obj, Test.Pass>(),
+  check<typeof res4, Promise<typeof obj>, Test.Pass>(),
+  check<typeof res5, Promise<typeof obj>, Test.Pass>(),
 ]);

--- a/type-check/fromEntries.test.ts
+++ b/type-check/fromEntries.test.ts
@@ -1,0 +1,31 @@
+import * as Test from "../src/types/Test";
+import { fromEntries, entries, pipe } from "../src";
+
+const { checks, check } = Test;
+
+const obj = {
+  a: 1,
+  b: true,
+  c: "hello",
+  d: { d1: 1, d2: 3 },
+};
+
+const arr = [
+  ["a", 1],
+  ["b", true],
+  ["c", "hello"],
+  ["d", { d1: 1, d2: 3 }],
+] as (
+  | ["a", number]
+  | ["b", boolean]
+  | ["c", string]
+  | ["d", { d1: number; d2: number }]
+)[];
+
+const res1 = fromEntries(arr);
+const res2 = pipe(obj, entries, fromEntries);
+
+checks([
+  check<typeof res1, typeof obj, Test.Pass>(),
+  check<typeof res2, typeof res1, Test.Pass>(),
+]);

--- a/website/function.json
+++ b/website/function.json
@@ -54,6 +54,7 @@
     "evolve",
     "find",
     "findIndex",
+    "fromEntries",
     "groupBy",
     "head",
     "identity",


### PR DESCRIPTION
Hi all,
I wrote a `fromEntries` function that performs inverse of `entries` function(key-value pair iterable/asyncIterable to an object).
This function supports type inference well.

My English is not very good, so there may be some strange English descriptions.

And also, maybe my test cases are weird or poorly written.

Any advice would be welcome. 😄 