### PR TITLE
fix: replace duplicated Iterable type with UniversalIterable

### DIFF
--- a/src/Lazy/append.ts
+++ b/src/Lazy/append.ts
@@ -2,6 +2,7 @@ import { isAsyncIterable, isIterable } from "../_internal/utils";
 import concurrent, { isConcurrent } from "./concurrent";
 import Awaited from "../types/Awaited";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 function* sync<A>(a: A, iterable: Iterable<A>) {
   yield* iterable;
@@ -108,13 +109,10 @@ function append<A>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A>;
 
-function append<A, B extends Iterable<A> | AsyncIterable<A>>(
+function append<A, B extends UniversalIterable<A>>(
   a: A,
-  iterable?: Iterable<A> | AsyncIterable<A>,
-):
-  | IterableIterator<A>
-  | AsyncIterableIterator<A>
-  | ((iterable: B) => ReturnIterableIteratorType<B, A>) {
+  iterable?: UniversalIterable<A>,
+): UniversalIterator<A> | ((iterable: B) => ReturnIterableIteratorType<B, A>) {
   if (iterable === undefined) {
     return (iterable: B) =>
       append(a, iterable as any) as ReturnIterableIteratorType<B, A>;

--- a/src/Lazy/chunk.ts
+++ b/src/Lazy/chunk.ts
@@ -9,6 +9,7 @@ import {
 import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import concurrent, { isConcurrent } from "./concurrent";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 function* sync<T>(size: number, iterable: Iterable<T>): IterableIterator<T[]> {
   const iterator = iterable[Symbol.iterator]();
@@ -110,16 +111,15 @@ function chunk<T>(
   iterable: AsyncIterable<T>,
 ): AsyncIterableIterator<T[]>;
 
-function chunk<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function chunk<T extends UniversalIterable<unknown>>(
   size: number,
 ): (iterable: T) => ReturnIterableIteratorType<T, IterableInfer<T>[]>;
 
-function chunk<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function chunk<T extends UniversalIterable<unknown>>(
   size: number,
   iterable?: T,
 ):
-  | IterableIterator<IterableInfer<T>[]>
-  | AsyncIterableIterator<IterableInfer<T>[]>
+  | UniversalIterator<IterableInfer<T>[]>
   | ((iterable: T) => ReturnIterableIteratorType<T, IterableInfer<T>[]>) {
   if (iterable === undefined) {
     return (iterable: T) =>

--- a/src/Lazy/compact.ts
+++ b/src/Lazy/compact.ts
@@ -1,5 +1,6 @@
 import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import { UniversalIterable } from "../types/Utils";
 import { isAsyncIterable, isIterable, isNotNullable } from "../_internal/utils";
 import filter from "./filter";
 
@@ -42,13 +43,11 @@ import filter from "./filter";
  * see {@link https://fxts.dev/docs/pipe | pipe}, {@link https://fxts.dev/docs/toAsync | toAsync},
  * {@link https://fxts.dev/docs/toArray | toArray}
  */
-function compact<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function compact<T extends UniversalIterable<unknown>>(
   iterable: T,
 ): ReturnIterableIteratorType<T, NonNullable<IterableInfer<T>>>;
 
-function compact<T extends Iterable<unknown> | AsyncIterable<unknown>>(
-  iterable: T,
-) {
+function compact<T extends UniversalIterable<unknown>>(iterable: T) {
   if (isIterable(iterable)) {
     return filter(isNotNullable, iterable);
   }

--- a/src/Lazy/compress.ts
+++ b/src/Lazy/compress.ts
@@ -3,6 +3,7 @@ import pipe from "../pipe";
 import filter from "./filter";
 import map from "./map";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import { UniversalIterable } from "../types/Utils";
 
 /**
  * Returns Iterable/AsyncIterable that filters elements from 'iterable' returning only those that have a corresponding element in 'selectors' that evaluates to 'true'.
@@ -40,11 +41,11 @@ function compress<A, B>(
   iterable: AsyncIterable<B>,
 ): AsyncIterableIterator<B>;
 
-function compress<A, B extends Iterable<unknown> | AsyncIterable<unknown>>(
+function compress<A, B extends UniversalIterable<unknown>>(
   selector: Array<A>,
 ): (iterable: B) => ReturnIterableIteratorType<B>;
 
-function compress<A, B extends Iterable<unknown> | AsyncIterable<unknown>>(
+function compress<A, B extends UniversalIterable<unknown>>(
   selectors: Array<A>,
   iterable?: B,
 ):

--- a/src/Lazy/concat.ts
+++ b/src/Lazy/concat.ts
@@ -1,5 +1,6 @@
 import IterableInfer from "../types/IterableInfer";
 import ReturnConcatType from "../types/ReturnConcatType";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 
 function* sync<A>(a: Iterable<A>, b: Iterable<A>): IterableIterator<A> {
@@ -34,9 +35,7 @@ function async<A>(
   };
 }
 
-function toAsyncIterable<T>(
-  iterable: Iterable<T> | AsyncIterable<T>,
-): AsyncIterable<T> {
+function toAsyncIterable<T>(iterable: UniversalIterable<T>): AsyncIterable<T> {
   if (isAsyncIterable(iterable)) {
     return iterable;
   }
@@ -89,24 +88,23 @@ function toAsyncIterable<T>(
  */
 // prettier-ignore
 function concat<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends Iterable<unknown> | AsyncIterable<unknown>
+  A extends UniversalIterable<unknown>,
+  B extends UniversalIterable<unknown>
 >(iterable1: A, iterable2: B): ReturnConcatType<A, B>;
 
 function concat<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends Iterable<unknown> | AsyncIterable<unknown>,
+  A extends UniversalIterable<unknown>,
+  B extends UniversalIterable<unknown>,
 >(iterable1: A): (iterable2: B) => ReturnConcatType<A, B>;
 
 function concat<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends Iterable<unknown> | AsyncIterable<unknown>,
+  A extends UniversalIterable<unknown>,
+  B extends UniversalIterable<unknown>,
 >(
   iterable1: A,
   iterable2?: B,
 ):
-  | IterableIterator<IterableInfer<A> | IterableInfer<B>>
-  | AsyncIterableIterator<IterableInfer<A> | IterableInfer<B>>
+  | UniversalIterator<IterableInfer<A> | IterableInfer<B>>
   | ((iterable2: B) => ReturnConcatType<A, B>) {
   if (iterable2 === undefined) {
     return (iterable2: B): ReturnConcatType<A, B> => {

--- a/src/Lazy/cycle.ts
+++ b/src/Lazy/cycle.ts
@@ -1,5 +1,6 @@
 import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import concurrent, { isConcurrent } from "./concurrent";
 
@@ -70,15 +71,13 @@ function async<T>(iterable: AsyncIterable<T>): AsyncIterableIterator<T> {
  * ); // [1,2,3,4,1]
  * ```
  */
-function cycle<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function cycle<A extends UniversalIterable<unknown>>(
   iter: A,
 ): ReturnIterableIteratorType<A>;
 
-function cycle<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function cycle<T extends UniversalIterable<unknown>>(
   iterable: T,
-):
-  | IterableIterator<IterableInfer<T>>
-  | AsyncIterableIterator<IterableInfer<T>> {
+): UniversalIterator<IterableInfer<T>> {
   if (isIterable<IterableInfer<T>>(iterable)) {
     return sync(iterable);
   }

--- a/src/Lazy/difference.ts
+++ b/src/Lazy/difference.ts
@@ -1,5 +1,6 @@
 import identity from "../identity";
 import IterableInfer from "../types/IterableInfer";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import differenceBy from "./differenceBy";
 
@@ -35,8 +36,8 @@ function difference<T>(
 ): AsyncIterableIterator<T>;
 
 function difference<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends Iterable<unknown> | AsyncIterable<unknown>,
+  A extends UniversalIterable<unknown>,
+  B extends UniversalIterable<unknown>,
 >(
   iterable1: A,
 ): (
@@ -48,14 +49,12 @@ function difference<
   : IterableIterator<IterableInfer<B>>;
 
 function difference<T>(
-  iterable1: Iterable<T> | AsyncIterable<T>,
-  iterable2?: Iterable<T> | AsyncIterable<T>,
+  iterable1: UniversalIterable<T>,
+  iterable2?: UniversalIterable<T>,
 ):
   | IterableIterator<T>
   | AsyncIterableIterator<T>
-  | ((
-      iterable2: Iterable<T> | AsyncIterable<T>,
-    ) => IterableIterator<T> | AsyncIterableIterator<T>) {
+  | ((iterable2: UniversalIterable<T>) => UniversalIterator<T>) {
   if (iterable2 === undefined) {
     return (iterable2: any) => {
       return difference(iterable1 as any, iterable2);

--- a/src/Lazy/differenceBy.ts
+++ b/src/Lazy/differenceBy.ts
@@ -7,6 +7,7 @@ import uniq from "./uniq";
 import pipe from "../pipe";
 import concurrent, { isConcurrent } from "./concurrent";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 function* sync<T>(
   f: (a: T) => unknown,
@@ -100,9 +101,9 @@ function differenceBy<A, B = unknown>(
 
 function differenceBy<A, B = unknown>(
   f: (a: A) => B,
-  iterable1: Iterable<A> | AsyncIterable<A>,
-  iterable2: Iterable<A> | AsyncIterable<A>,
-): IterableIterator<A> | AsyncIterableIterator<A> {
+  iterable1: UniversalIterable<A>,
+  iterable2: UniversalIterable<A>,
+): UniversalIterator<A> {
   if (isIterable(iterable1) && isIterable(iterable2)) {
     return sync(f, iterable1, iterable2);
   }

--- a/src/Lazy/drop.ts
+++ b/src/Lazy/drop.ts
@@ -1,4 +1,5 @@
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import concurrent, { isConcurrent } from "./concurrent";
 
@@ -104,17 +105,14 @@ function drop<A>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A>;
 
-function drop<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function drop<A extends UniversalIterable<unknown>>(
   length: number,
 ): (iterable: A) => ReturnIterableIteratorType<A>;
 
-function drop<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function drop<A extends UniversalIterable<unknown>>(
   length: number,
   iterable?: A,
-):
-  | IterableIterator<A>
-  | AsyncIterableIterator<A>
-  | ((iterable: A) => ReturnIterableIteratorType<A>) {
+): UniversalIterator<A> | ((iterable: A) => ReturnIterableIteratorType<A>) {
   if (iterable === undefined) {
     return (iterable: A): ReturnIterableIteratorType<A> => {
       return drop(length, iterable as any) as ReturnIterableIteratorType<A>;

--- a/src/Lazy/dropUntil.ts
+++ b/src/Lazy/dropUntil.ts
@@ -1,5 +1,6 @@
 import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 import { AsyncFunctionException } from "../_internal/error";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import concurrent, { isConcurrent } from "./concurrent";
@@ -118,16 +119,15 @@ function dropUntil<A, B = unknown>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A>;
 
-function dropUntil<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function dropUntil<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
 ): (iterable: A) => ReturnIterableIteratorType<A>;
 
-function dropUntil<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function dropUntil<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ):
-  | IterableIterator<IterableInfer<A>>
-  | AsyncIterableIterator<IterableInfer<A>>
+  | UniversalIterator<IterableInfer<A>>
   | ((iterable: A) => ReturnIterableIteratorType<A>) {
   if (iterable === undefined) {
     return (iterable: A) => {

--- a/src/Lazy/dropWhile.ts
+++ b/src/Lazy/dropWhile.ts
@@ -1,5 +1,6 @@
 import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 import { AsyncFunctionException } from "../_internal/error";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import concurrent, { isConcurrent } from "./concurrent";
@@ -122,16 +123,15 @@ function dropWhile<A, B = unknown>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A>;
 
-function dropWhile<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function dropWhile<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
 ): (iterable: A) => ReturnIterableIteratorType<A>;
 
-function dropWhile<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function dropWhile<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ):
-  | IterableIterator<IterableInfer<A>>
-  | AsyncIterableIterator<IterableInfer<A>>
+  | UniversalIterator<IterableInfer<A>>
   | ((iterable: A) => ReturnIterableIteratorType<A>) {
   if (iterable === undefined) {
     return (iterable: A) => {

--- a/src/Lazy/filter.ts
+++ b/src/Lazy/filter.ts
@@ -4,7 +4,12 @@ import pipe1 from "../pipe1";
 import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import TruthyTypesOf from "../types/TrutyTypesOf";
-import { Reject, Resolve } from "../types/Utils";
+import {
+  Reject,
+  Resolve,
+  UniversalIterable,
+  UniversalIterator,
+} from "../types/Utils";
 import { AsyncFunctionException } from "../_internal/error";
 
 async function* asyncSequential<A>(
@@ -243,37 +248,29 @@ function filter<A, B = unknown>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A>;
 
-function filter<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function filter<A extends UniversalIterable<unknown>>(
   f: BooleanConstructor,
 ): (
   iterable: A,
 ) => ReturnIterableIteratorType<A, TruthyTypesOf<IterableInfer<A>>>;
 
 function filter<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
+  A extends UniversalIterable<unknown>,
   B extends IterableInfer<A>,
 >(
   f: (a: IterableInfer<A>) => a is B,
 ): (iterable: A) => ReturnIterableIteratorType<A, B>;
 
-function filter<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B = unknown,
->(
+function filter<A extends UniversalIterable<unknown>, B = unknown>(
   f: (a: IterableInfer<A>) => B,
 ): (iterable: A) => ReturnIterableIteratorType<A, IterableInfer<A>>;
 
-function filter<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B = unknown,
->(
+function filter<A extends UniversalIterable<unknown>, B = unknown>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ):
-  | IterableIterator<IterableInfer<A>>
-  | IterableIterator<TruthyTypesOf<IterableInfer<A>>>
-  | AsyncIterableIterator<IterableInfer<A>>
-  | AsyncIterableIterator<TruthyTypesOf<IterableInfer<A>>>
+  | UniversalIterator<IterableInfer<A>>
+  | UniversalIterator<TruthyTypesOf<IterableInfer<A>>>
   | ((iterable: A) => ReturnIterableIteratorType<A, IterableInfer<A>>)
   | ((
       iterable: A,

--- a/src/Lazy/flat.ts
+++ b/src/Lazy/flat.ts
@@ -4,7 +4,7 @@ import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import DeepFlat from "../types/DeepFlat";
 import { empty, isAsyncIterable, isIterable } from "../_internal/utils";
-import { Reject, Resolve } from "../types/Utils";
+import { Reject, Resolve, UniversalIterable } from "../types/Utils";
 import append from "./append";
 import concat from "./concat";
 
@@ -216,14 +216,14 @@ function async<A>(
  */
 // prettier-ignore
 function flat<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
+  A extends UniversalIterable<unknown>,
   B extends number = 1
 >(
   iterator: A,
   depth?: B
 ): ReturnIterableIteratorType<A, DeepFlat<IterableInfer<A>, B>>;
 
-function flat<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function flat<A extends UniversalIterable<unknown>>(
   iterable: Iterable<A> | AsyncIterable<A>,
   depth = 1,
 ) {

--- a/src/Lazy/flatMap.ts
+++ b/src/Lazy/flatMap.ts
@@ -5,10 +5,11 @@ import Awaited from "../types/Awaited";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import IterableInfer from "../types/IterableInfer";
 import DeepFlat from "../types/DeepFlat";
+import { UniversalIterable } from "../types/Utils";
 
 type FlatMapValue<
   T,
-  I extends Iterable<unknown> | AsyncIterable<unknown>,
+  I extends UniversalIterable<unknown>,
 > = I extends AsyncIterable<any> ? Awaited<T> : T;
 
 /**
@@ -62,20 +63,14 @@ function flatMap<A, B = unknown>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<DeepFlat<Awaited<B>, 1>>;
 
-function flatMap<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B = unknown,
->(
+function flatMap<A extends UniversalIterable<unknown>, B = unknown>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ): (
   iterable: A,
 ) => ReturnIterableIteratorType<A, DeepFlat<FlatMapValue<B, A>, 1>>;
 
-function flatMap<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B = unknown,
->(
+function flatMap<A extends UniversalIterable<unknown>, B = unknown>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ):

--- a/src/Lazy/intersection.ts
+++ b/src/Lazy/intersection.ts
@@ -1,5 +1,6 @@
 import identity from "../identity";
 import IterableInfer from "../types/IterableInfer";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import intersectionBy from "./intersectionBy";
 
@@ -34,8 +35,8 @@ function intersection<T>(
 ): AsyncIterableIterator<T>;
 
 function intersection<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends Iterable<unknown> | AsyncIterable<unknown>,
+  A extends UniversalIterable<unknown>,
+  B extends UniversalIterable<unknown>,
 >(
   iterable1: A,
 ): (
@@ -47,14 +48,11 @@ function intersection<
   : IterableIterator<IterableInfer<B>>;
 
 function intersection<T>(
-  iterable1: Iterable<T> | AsyncIterable<T>,
-  iterable2?: Iterable<T> | AsyncIterable<T>,
+  iterable1: UniversalIterable<T>,
+  iterable2?: UniversalIterable<T>,
 ):
-  | IterableIterator<T>
-  | AsyncIterableIterator<T>
-  | ((
-      iterable2: Iterable<T> | AsyncIterable<T>,
-    ) => IterableIterator<T> | AsyncIterableIterator<T>) {
+  | UniversalIterator<T>
+  | ((iterable2: UniversalIterable<T>) => UniversalIterator<T>) {
   if (iterable2 === undefined) {
     return (iterable2: any) => {
       return intersection(iterable1 as any, iterable2);

--- a/src/Lazy/intersectionBy.ts
+++ b/src/Lazy/intersectionBy.ts
@@ -7,6 +7,7 @@ import { isAsyncIterable, isIterable } from "../_internal/utils";
 import pipe1 from "../pipe1";
 import pipe from "../pipe";
 import uniq from "./uniq";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 function* sync<T>(
   f: (a: T) => unknown,
@@ -99,9 +100,9 @@ function intersectionBy<A, B = unknown>(
 
 function intersectionBy<A, B = unknown>(
   f: (a: A) => B,
-  iterable1: Iterable<A> | AsyncIterable<A>,
-  iterable2: Iterable<A> | AsyncIterable<A>,
-): IterableIterator<A> | AsyncIterableIterator<A> {
+  iterable1: UniversalIterable<A>,
+  iterable2: UniversalIterable<A>,
+): UniversalIterator<A> {
   if (isIterable(iterable1) && isIterable(iterable2)) {
     return sync(f, iterable1, iterable2);
   }

--- a/src/Lazy/map.ts
+++ b/src/Lazy/map.ts
@@ -3,6 +3,7 @@ import Awaited from "../types/Awaited";
 import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import { AsyncFunctionException } from "../_internal/error";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 function sync<A, B>(
   f: (a: A) => B,
@@ -115,17 +116,14 @@ function map<A, B>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<Awaited<B>>;
 
-function map<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function map<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
 ): (iterable: A) => ReturnIterableIteratorType<A, B>;
 
-function map<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function map<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
-):
-  | IterableIterator<B>
-  | AsyncIterableIterator<B>
-  | ((iterable: A) => ReturnIterableIteratorType<A, B>) {
+): UniversalIterator<B> | ((iterable: A) => ReturnIterableIteratorType<A, B>) {
   if (iterable === undefined) {
     return (iterable: A): ReturnIterableIteratorType<A, B> => {
       return map(f, iterable as any) as ReturnIterableIteratorType<A, B>;

--- a/src/Lazy/peek.ts
+++ b/src/Lazy/peek.ts
@@ -4,6 +4,7 @@ import { isAsyncIterable, isIterable } from "../_internal/utils";
 import Awaited from "../types/Awaited";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import IterableInfer from "../types/IterableInfer";
+import { UniversalIterable } from "../types/Utils";
 
 /**
  * Iterate over an input list,
@@ -63,11 +64,11 @@ function peek<T>(
   iterable: AsyncIterable<T>,
 ): AsyncIterableIterator<T>;
 
-function peek<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function peek<T extends UniversalIterable<unknown>>(
   f: (a: Awaited<IterableInfer<T>>) => unknown,
 ): (iterable: T) => ReturnIterableIteratorType<T>;
 
-function peek<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function peek<T extends UniversalIterable<unknown>>(
   f: (a: Awaited<IterableInfer<T>>) => unknown,
   iterable?: T,
 ):

--- a/src/Lazy/pluck.ts
+++ b/src/Lazy/pluck.ts
@@ -1,5 +1,6 @@
 import map from "./map";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 /**
  * Returns Iterable/AsyncIterable by plucking the same named property off all objects in Iterable/AsyncIterable supplied.
@@ -57,10 +58,9 @@ function pluck<O extends object, K extends keyof O>(
 
 function pluck<O extends object, K extends keyof O>(
   key: K,
-  iterable?: Iterable<O> | AsyncIterable<O>,
+  iterable?: UniversalIterable<O>,
 ):
-  | IterableIterator<O[K]>
-  | AsyncIterableIterator<O[K]>
+  | UniversalIterator<O[K]>
   | ((iterable: Iterable<O>) => IterableIterator<O[K]>)
   | ((iterable: AsyncIterable<O>) => AsyncIterableIterator<O[K]>) {
   if (iterable === undefined) {

--- a/src/Lazy/prepend.ts
+++ b/src/Lazy/prepend.ts
@@ -1,5 +1,6 @@
 import Awaited from "../types/Awaited";
 import ReturnPrependType from "../types/ReturnPrependType";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 
 function* sync<A>(a: A, iterable: Iterable<A>): IterableIterator<A> {
@@ -79,11 +80,8 @@ function prepend<A>(
 
 function prepend<A, B extends Iterable<A> | AsyncIterable<Awaited<A>>>(
   a: A,
-  iterable?: Iterable<A> | AsyncIterable<A>,
-):
-  | IterableIterator<A>
-  | AsyncIterableIterator<A>
-  | ((iterable: B) => ReturnPrependType<A, B>) {
+  iterable?: UniversalIterable<A>,
+): UniversalIterator<A> | ((iterable: B) => ReturnPrependType<A, B>) {
   if (iterable === undefined) {
     return (iterable: B) =>
       prepend(a, iterable as any) as ReturnPrependType<A, B>;

--- a/src/Lazy/reject.ts
+++ b/src/Lazy/reject.ts
@@ -4,6 +4,7 @@ import not from "../not";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 /**
  * The opposite of {@link https://fxts.dev/docs/filter | filter}
@@ -63,23 +64,16 @@ function reject<A, B = unknown>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A>;
 
-function reject<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B = unknown,
->(
+function reject<A extends UniversalIterable<unknown>, B = unknown>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ): (iterable: A) => ReturnIterableIteratorType<A, IterableInfer<A>>;
 
-function reject<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B = unknown,
->(
+function reject<A extends UniversalIterable<unknown>, B = unknown>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ):
-  | IterableIterator<IterableInfer<A>>
-  | AsyncIterableIterator<IterableInfer<A>>
+  | UniversalIterator<IterableInfer<A>>
   | ((iterable: A) => ReturnIterableIteratorType<A, IterableInfer<A>>) {
   if (iterable === undefined) {
     return (iterable: A): ReturnIterableIteratorType<A, IterableInfer<A>> => {

--- a/src/Lazy/reverse.ts
+++ b/src/Lazy/reverse.ts
@@ -4,6 +4,7 @@ import isString from "../isString";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import concurrent, { isConcurrent } from "./concurrent";
+import { UniversalIterable } from "../types/Utils";
 
 function* stringReverse(str: string) {
   const arr = Array.from(str);
@@ -85,13 +86,11 @@ function async<T>(iterable: AsyncIterable<T>): AsyncIterableIterator<T> {
  *
  * see {@link https://fxts.dev/docs/pipe | pipe} {@link https://fxts.dev/docs/toArray | toArray}
  */
-function reverse<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function reverse<T extends UniversalIterable<unknown>>(
   iterable: T,
 ): ReturnIterableIteratorType<T>;
 
-function reverse<T extends Iterable<unknown> | AsyncIterable<unknown>>(
-  iterable: T,
-) {
+function reverse<T extends UniversalIterable<unknown>>(iterable: T) {
   if (isArray(iterable)) {
     return arrayReverse(iterable);
   }

--- a/src/Lazy/scan.ts
+++ b/src/Lazy/scan.ts
@@ -6,6 +6,7 @@ import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import { empty, isAsyncIterable, isIterable } from "../_internal/utils";
 import concurrent, { isConcurrent } from "./concurrent";
 import head from "../head";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 function* sync<A, B>(
   f: (a: B, b: A) => B,
@@ -138,14 +139,14 @@ function scan<A, B>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<Awaited<B>>;
 
-function scan<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function scan<A extends UniversalIterable<unknown>>(
   f: (
     a: IterableInfer<A>,
     b: IterableInfer<A>,
   ) => IterableInfer<A> | Promise<IterableInfer<A>>,
 ): (iterable: A) => ReturnIterableIteratorType<A, IterableInfer<A>>;
 
-function scan<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function scan<A extends UniversalIterable<unknown>, B>(
   f: (a: B, b: IterableInfer<A>) => B | Promise<B>,
 ): (iterable: A) => ReturnIterableIteratorType<A, B>;
 
@@ -153,10 +154,7 @@ function scan<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
   f: (a: B, b: IterableInfer<A>) => B,
   seed?: B | Iterable<IterableInfer<A>> | AsyncIterable<IterableInfer<A>>,
   iterable?: Iterable<IterableInfer<A>> | AsyncIterable<IterableInfer<A>>,
-):
-  | IterableIterator<B>
-  | AsyncIterableIterator<B>
-  | ((iterable: A) => ReturnIterableIteratorType<A, B>) {
+): UniversalIterator<B> | ((iterable: A) => ReturnIterableIteratorType<A, B>) {
   if (iterable === undefined) {
     if (seed === undefined) {
       return (iterable: A) => {

--- a/src/Lazy/slice.ts
+++ b/src/Lazy/slice.ts
@@ -1,5 +1,6 @@
 import isNumber from "../isNumber";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import { UniversalIterable } from "../types/Utils";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import concurrent, { isConcurrent } from "./concurrent";
 
@@ -55,7 +56,7 @@ function async<T>(
   };
 }
 
-function _slice<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function _slice<T extends UniversalIterable<unknown>>(
   start: number,
   end: number,
   iterable: T,
@@ -134,16 +135,16 @@ function slice<T>(
   iterable: AsyncIterable<T>,
 ): AsyncIterableIterator<T>;
 
-function slice<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function slice<A extends UniversalIterable<unknown>>(
   start: number,
 ): (iterable: A) => ReturnIterableIteratorType<A>;
 
-function slice<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function slice<A extends UniversalIterable<unknown>>(
   start: number,
   end: number,
 ): (iterable: A) => ReturnIterableIteratorType<A>;
 
-function slice<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function slice<T extends UniversalIterable<unknown>>(
   start: number | T,
   end?: number | T,
   iterable?: T,

--- a/src/Lazy/split.ts
+++ b/src/Lazy/split.ts
@@ -1,4 +1,5 @@
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import concurrent, { isConcurrent } from "./concurrent";
 
@@ -100,16 +101,15 @@ function split(
   iterable: AsyncIterable<string>,
 ): AsyncIterableIterator<string>;
 
-function split<A extends Iterable<string> | AsyncIterable<string>>(
+function split<A extends UniversalIterable<string>>(
   sep: string,
 ): (iterable: A) => ReturnIterableIteratorType<A, string>;
 
-function split<A extends Iterable<string> | AsyncIterable<string>>(
+function split<A extends UniversalIterable<string>>(
   sep: string,
   iterable?: A,
 ):
-  | IterableIterator<string>
-  | AsyncIterableIterator<string>
+  | UniversalIterator<string>
   | ((iterable: A) => ReturnIterableIteratorType<A, string>) {
   if (iterable === undefined) {
     return (iterable: A): ReturnIterableIteratorType<A, string> => {

--- a/src/Lazy/take.ts
+++ b/src/Lazy/take.ts
@@ -1,6 +1,7 @@
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import IterableInfer from "../types/IterableInfer";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 function* sync<A>(length: number, iterable: Iterable<A>): IterableIterator<A> {
   const iterator = iterable[Symbol.iterator]();
@@ -75,16 +76,15 @@ function take<A>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A>;
 
-function take<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function take<A extends UniversalIterable<unknown>>(
   l: number,
 ): (iterable: A) => ReturnIterableIteratorType<A>;
 
-function take<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function take<A extends UniversalIterable<unknown>>(
   l: number,
   iterable?: A,
 ):
-  | IterableIterator<IterableInfer<A>>
-  | AsyncIterableIterator<IterableInfer<A>>
+  | UniversalIterator<IterableInfer<A>>
   | ((iterable: A) => ReturnIterableIteratorType<A>) {
   if (iterable === undefined) {
     return (iterable: A) => {

--- a/src/Lazy/takeUntil.ts
+++ b/src/Lazy/takeUntil.ts
@@ -3,6 +3,7 @@ import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import { AsyncFunctionException } from "../_internal/error";
 import concurrent, { isConcurrent } from "./concurrent";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 function* sync<A, B>(f: (a: A) => B, iterable: Iterable<A>) {
   for (const item of iterable) {
@@ -129,16 +130,15 @@ function takeUntil<A, B>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A>;
 
-function takeUntil<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function takeUntil<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
 ): (iterable: A) => ReturnIterableIteratorType<A>;
 
-function takeUntil<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function takeUntil<A extends UniversalIterable<unknown>, B>(
   f: (a: A) => B,
   iterable?: Iterable<A> | AsyncIterable<A>,
 ):
-  | IterableIterator<IterableInfer<A>>
-  | AsyncIterableIterator<IterableInfer<A>>
+  | UniversalIterator<IterableInfer<A>>
   | ((iterable: A) => ReturnIterableIteratorType<A>) {
   if (iterable === undefined) {
     return (iterable: A) => {

--- a/src/Lazy/takeWhile.ts
+++ b/src/Lazy/takeWhile.ts
@@ -3,6 +3,7 @@ import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import { AsyncFunctionException } from "../_internal/error";
 import concurrent, { isConcurrent } from "./concurrent";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 function* sync<A, B>(f: (a: A) => B, iterable: Iterable<A>) {
   for (const item of iterable) {
@@ -121,16 +122,15 @@ function takeWhile<A, B>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A>;
 
-function takeWhile<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function takeWhile<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
 ): (iterable: A) => ReturnIterableIteratorType<A>;
 
-function takeWhile<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function takeWhile<A extends UniversalIterable<unknown>, B>(
   f: (a: A) => B,
   iterable?: Iterable<A> | AsyncIterable<A>,
 ):
-  | IterableIterator<IterableInfer<A>>
-  | AsyncIterableIterator<IterableInfer<A>>
+  | UniversalIterator<IterableInfer<A>>
   | ((iterable: A) => ReturnIterableIteratorType<A>) {
   if (iterable === undefined) {
     return (iterable: A) => {

--- a/src/Lazy/uniq.ts
+++ b/src/Lazy/uniq.ts
@@ -2,6 +2,7 @@ import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import uniqueBy from "./uniqBy";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import identity from "../identity";
+import { UniversalIterable } from "../types/Utils";
 
 /**
  * Returns Iterable/AsyncIterable with duplicate values removed inside the given Iterable/AsyncIterable.
@@ -42,7 +43,7 @@ import identity from "../identity";
  * see {@link https://fxts.dev/docs/pipe | pipe}, {@link https://fxts.dev/docs/toAsync | toAsync},
  * {@link https://fxts.dev/docs/toArray | toArray}
  */
-function uniq<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function uniq<A extends UniversalIterable<unknown>>(
   iterable: A,
 ): ReturnIterableIteratorType<A> {
   if (isIterable(iterable)) {

--- a/src/Lazy/uniqBy.ts
+++ b/src/Lazy/uniqBy.ts
@@ -4,6 +4,7 @@ import filter from "./filter";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import IterableInfer from "../types/IterableInfer";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
 /**
  * Unlike {@link https://fxts.dev/docs/uniq | uniq} returns Iterable/AsyncIterable
@@ -62,18 +63,15 @@ function uniqBy<A, B>(
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A>;
 
-function uniqBy<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function uniqBy<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ): (iterable: A) => ReturnIterableIteratorType<A>;
 
-function uniqBy<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function uniqBy<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
-):
-  | IterableIterator<A>
-  | AsyncIterableIterator<A>
-  | ((iterable: A) => ReturnIterableIteratorType<A>) {
+): UniversalIterator<A> | ((iterable: A) => ReturnIterableIteratorType<A>) {
   if (iterable === undefined) {
     return (iterable) => {
       return uniqBy(f, iterable as any) as ReturnIterableIteratorType<A>;

--- a/src/Lazy/zipWith.ts
+++ b/src/Lazy/zipWith.ts
@@ -1,3 +1,4 @@
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import map from "./map";
 import zip from "./zip";
@@ -40,9 +41,9 @@ function zipWith<A, B, C>(
 
 function zipWith<A, B, C>(
   f: (a: A, b: B) => C,
-  iterable1: Iterable<A> | AsyncIterable<A>,
-  iterable2: Iterable<B> | AsyncIterable<B>,
-): IterableIterator<C> | AsyncIterableIterator<C> {
+  iterable1: UniversalIterable<A>,
+  iterable2: UniversalIterable<B>,
+): UniversalIterator<C> {
   if (isIterable(iterable1) && isIterable(iterable2)) {
     return map(([a, b]) => f(a, b), zip(iterable1, iterable2));
   }

--- a/src/Lazy/zipWithIndex.ts
+++ b/src/Lazy/zipWithIndex.ts
@@ -2,8 +2,9 @@ import map from "./map";
 import concurrent, { isConcurrent } from "./concurrent";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import ReturnZipWithIndexType from "../types/ReturnZipWithIndexType";
+import { UniversalIterable, UniversalIterator } from "../types/Utils";
 
-function _zipWithIndex<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function _zipWithIndex<T extends UniversalIterable<unknown>>(
   iterable: T,
 ): ReturnZipWithIndexType<T> {
   let i = -1;
@@ -67,13 +68,13 @@ function async<T>(iterable: AsyncIterable<T>) {
  * see {@link https://fxts.dev/docs/pipe | pipe}, {@link https://fxts.dev/docs/toAsync | toAsync},
  * {@link https://fxts.dev/docs/toArray | toArray}
  */
-function zipWithIndex<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function zipWithIndex<T extends UniversalIterable<unknown>>(
   iterable: T,
 ): ReturnZipWithIndexType<T>;
 
 function zipWithIndex<T>(
-  iterable: Iterable<T> | AsyncIterable<T>,
-): IterableIterator<[number, T]> | AsyncIterableIterator<[number, T]> {
+  iterable: UniversalIterable<T>,
+): UniversalIterator<[number, T]> {
   if (isAsyncIterable(iterable)) {
     return async(iterable);
   }

--- a/src/average.ts
+++ b/src/average.ts
@@ -2,6 +2,7 @@ import peek from "./Lazy/peek";
 import pipe from "./pipe";
 import sum from "./sum";
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 /**
@@ -22,7 +23,7 @@ import { isAsyncIterable, isIterable } from "./_internal/utils";
  *
  * see {@link https://fxts.dev/docs/pipe | pipe}
  */
-function average<T extends Iterable<number> | AsyncIterable<number>>(
+function average<T extends UniversalIterable<number>>(
   iterable: T,
 ): ReturnValueType<T> {
   let size = 0;

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -1,6 +1,7 @@
 import ReturnValueType from "./types/ReturnValueType";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 import range from "./Lazy/range";
+import { UniversalIterable } from "./types/Utils";
 
 function sync<T>(iterable: Iterable<T>, n: number) {
   const iterator = iterable[Symbol.iterator]();
@@ -45,12 +46,12 @@ async function async<T>(iterable: AsyncIterable<T>, n: number) {
  * );
  * ```
  */
-function consume<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends number,
->(iterator: A, n?: B): ReturnValueType<A, void>;
+function consume<A extends UniversalIterable<unknown>, B extends number>(
+  iterator: A,
+  n?: B,
+): ReturnValueType<A, void>;
 
-function consume<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function consume<A extends UniversalIterable<unknown>>(
   iterable: A,
   n = Infinity,
 ) {

--- a/src/countBy.ts
+++ b/src/countBy.ts
@@ -4,6 +4,7 @@ import IterableInfer from "./types/IterableInfer";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 import { AsyncFunctionException } from "./_internal/error";
 import reduce from "./reduce";
+import { UniversalIterable } from "./types/Utils";
 
 function incSel<B extends Key>(parent: { [K in B]: number }, k: B) {
   parent[k] ? parent[k]++ : (parent[k] = 1);
@@ -46,17 +47,11 @@ function countBy<A, B extends Key>(
   iterable: AsyncIterable<A>,
 ): Promise<{ [K in B]: number }>;
 
-function countBy<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends Key,
->(
+function countBy<A extends UniversalIterable<unknown>, B extends Key>(
   f: (a: IterableInfer<A>) => B | Promise<B>,
 ): (iterable: A) => ReturnValueType<A, { [K in B]: number }>;
 
-function countBy<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends Key,
->(
+function countBy<A extends UniversalIterable<unknown>, B extends Key>(
   f: (a: IterableInfer<A>) => B | Promise<B>,
   iterable?: A,
 ):

--- a/src/each.ts
+++ b/src/each.ts
@@ -1,5 +1,6 @@
 import IterableInfer from "./types/IterableInfer";
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 function sync<A, B = unknown>(f: (a: A) => B, iterable: Iterable<A>): void {
@@ -41,12 +42,11 @@ function each<A, B = unknown>(
   iterable: AsyncIterable<A>,
 ): Promise<void>;
 
-function each<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B = unknown,
->(f: (a: IterableInfer<A>) => B): (iterable: A) => ReturnValueType<A, void>;
+function each<A extends UniversalIterable<unknown>, B = unknown>(
+  f: (a: IterableInfer<A>) => B,
+): (iterable: A) => ReturnValueType<A, void>;
 
-function each<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function each<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ): void | Promise<void> | ((iterable: A) => ReturnValueType<A, void>) {

--- a/src/every.ts
+++ b/src/every.ts
@@ -7,6 +7,7 @@ import { isAsyncIterable, isIterable } from "./_internal/utils";
 import IterableInfer from "./types/IterableInfer";
 import ReturnValueType from "./types/ReturnValueType";
 import Arrow from "./types/Arrow";
+import { UniversalIterable } from "./types/Utils";
 
 /**
  * Returns true if all of the values in Iterable/AsyncIterable pass the `f` truth test.
@@ -36,15 +37,11 @@ function every<A, B = unknown>(
   iterable: AsyncIterable<A>,
 ): Promise<boolean>;
 
-function every<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B = unknown,
->(f: (a: IterableInfer<A>) => B): (a: A) => ReturnValueType<A, boolean>;
+function every<A extends UniversalIterable<unknown>, B = unknown>(
+  f: (a: IterableInfer<A>) => B,
+): (a: A) => ReturnValueType<A, boolean>;
 
-function every<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B = unknown,
->(
+function every<A extends UniversalIterable<unknown>, B = unknown>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ): boolean | Promise<boolean> | ((iterable: A) => ReturnValueType<A, boolean>) {

--- a/src/find.ts
+++ b/src/find.ts
@@ -3,6 +3,7 @@ import head from "./head";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 import ReturnValueType from "./types/ReturnValueType";
 import IterableInfer from "./types/IterableInfer";
+import { UniversalIterable } from "./types/Utils";
 
 /**
  * Looks through each value in Iterable/AsyncIterable, returning the first one that passes a truth test `f`,
@@ -24,12 +25,12 @@ function find<T>(
   iterable: AsyncIterable<T>,
 ): Promise<T | undefined>;
 
-function find<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function find<T extends UniversalIterable<unknown>>(
   f: (a: IterableInfer<T>) => unknown,
   iterable?: T,
 ): (iterable: T) => ReturnValueType<T, IterableInfer<T> | undefined>;
 
-function find<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function find<T extends UniversalIterable<unknown>>(
   f: (a: IterableInfer<T>) => unknown,
   iterable?: T,
 ):

--- a/src/findIndex.ts
+++ b/src/findIndex.ts
@@ -5,6 +5,7 @@ import pipe1 from "./pipe1";
 import Arrow from "./types/Arrow";
 import IterableInfer from "./types/IterableInfer";
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 /**
@@ -27,12 +28,12 @@ function findIndex<T>(
   iterable: AsyncIterable<T>,
 ): Promise<number>;
 
-function findIndex<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function findIndex<T extends UniversalIterable<unknown>>(
   f: (a: IterableInfer<T>) => unknown,
   iterable?: T,
 ): (iterable: T) => ReturnValueType<T, number>;
 
-function findIndex<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function findIndex<T extends UniversalIterable<unknown>>(
   f: (a: IterableInfer<T>) => unknown,
   iterable?: T,
 ): number | Promise<number> | ((iterable: T) => ReturnValueType<T, number>) {

--- a/src/fromEntries.ts
+++ b/src/fromEntries.ts
@@ -2,6 +2,7 @@ import reduce from "./reduce";
 import IterableInfer from "./types/IterableInfer";
 import Key from "./types/Key";
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 /**
@@ -29,7 +30,7 @@ import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 function fromEntries<
   U extends [Key, any] | readonly [Key, any],
-  T extends Iterable<U> | AsyncIterable<U>,
+  T extends UniversalIterable<U>,
 >(
   iterable: T,
 ): ReturnValueType<

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -5,6 +5,7 @@ import { isAsyncIterable, isIterable } from "./_internal/utils";
 import { AsyncFunctionException } from "./_internal/error";
 import reduce from "./reduce";
 import iterableInfer from "./types/IterableInfer";
+import { UniversalIterable } from "./types/Utils";
 
 /**
  * Splits Iterable/AsyncIterable into sets, grouped by the result of running each value through `f`.
@@ -46,17 +47,11 @@ function groupBy<A, B extends Key>(
   iterable: AsyncIterable<A>,
 ): Promise<{ [K in B]: A[] }>;
 
-function groupBy<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends Key,
->(
+function groupBy<A extends UniversalIterable<unknown>, B extends Key>(
   f: (a: IterableInfer<A>) => B | Promise<B>,
 ): (iterable: A) => ReturnValueType<A, { [K in B]: IterableInfer<A>[] }>;
 
-function groupBy<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends Key,
->(
+function groupBy<A extends UniversalIterable<unknown>, B extends Key>(
   f: (a: IterableInfer<A>) => B | Promise<B>,
   iterable?: A,
 ):

--- a/src/head.ts
+++ b/src/head.ts
@@ -1,6 +1,7 @@
 import take from "./Lazy/take";
 import pipe from "./pipe";
 import toArray from "./toArray";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 type HeadReturnType<T> = T extends readonly [a: infer H, ...rest: any[]]
@@ -43,11 +44,11 @@ type HeadReturnType<T> = T extends readonly [a: infer H, ...rest: any[]]
  *
  * see {@link https://fxts.dev/docs/pipe | pipe}, {@link https://fxts.dev/docs/toAsync | toAsync}
  */
-function head<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function head<T extends UniversalIterable<unknown>>(
   iterable: T,
 ): HeadReturnType<T>;
 
-function head<A>(iterable: Iterable<A> | AsyncIterable<A>) {
+function head<A>(iterable: UniversalIterable<A>) {
   if (isIterable(iterable)) {
     return pipe(take(1, iterable), toArray, ([a]) => a);
   }

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -1,5 +1,6 @@
 import some from "./some";
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 /**
@@ -26,11 +27,11 @@ function includes<T>(
   iterable: AsyncIterable<T>,
 ): Promise<boolean>;
 
-function includes<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function includes<T extends UniversalIterable<unknown>>(
   value: unknown,
 ): (iterable: T) => ReturnValueType<T, boolean>;
 
-function includes<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function includes<T extends UniversalIterable<unknown>>(
   value: unknown,
   iterable?: T,
 ): boolean | Promise<boolean> | ((iterable: T) => ReturnValueType<T, boolean>) {

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -4,6 +4,7 @@ import IterableInfer from "./types/IterableInfer";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 import reduce from "./reduce";
 import { AsyncFunctionException } from "./_internal/error";
+import { UniversalIterable } from "./types/Utils";
 
 /**
  * Given `f` that generates a key,
@@ -38,17 +39,11 @@ function indexBy<A, B extends Key>(
   iterable: AsyncIterable<A>,
 ): Promise<{ [K in B]: A }>;
 
-function indexBy<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends Key,
->(
+function indexBy<A extends UniversalIterable<unknown>, B extends Key>(
   f: (a: IterableInfer<A>) => B | Promise<B>,
 ): (iterable: A) => ReturnValueType<A, { [K in B]: IterableInfer<A> }>;
 
-function indexBy<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B extends Key,
->(
+function indexBy<A extends UniversalIterable<unknown>, B extends Key>(
   f: (a: IterableInfer<A>) => B | Promise<B>,
   iterable?: A,
 ):

--- a/src/join.ts
+++ b/src/join.ts
@@ -1,7 +1,8 @@
 import reduce from "./reduce";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
-type ReturnJoinType<T extends Iterable<unknown> | AsyncIterable<unknown>> =
+type ReturnJoinType<T extends UniversalIterable<unknown>> =
   T extends Iterable<unknown>
     ? string
     : T extends AsyncIterable<unknown>
@@ -52,11 +53,11 @@ function join<A>(sep: string, iterable: Iterable<A>): string;
 
 function join<A>(sep: string, iterable: AsyncIterable<A>): Promise<string>;
 
-function join<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function join<A extends UniversalIterable<unknown>>(
   sep: string,
 ): (iterable: A) => ReturnJoinType<A>;
 
-function join<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function join<A extends UniversalIterable<unknown>>(
   sep: string,
   iterable?: A,
 ): string | Promise<string> | ((iterable: A) => ReturnJoinType<A>) {

--- a/src/last.ts
+++ b/src/last.ts
@@ -1,6 +1,7 @@
 import isArray from "./isArray";
 import isString from "./isString";
 import reduce from "./reduce";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 type LastReturnType<T> = T extends readonly [...rest: any[], a: infer L]
@@ -43,11 +44,11 @@ type LastReturnType<T> = T extends readonly [...rest: any[], a: infer L]
  *
  * see {@link https://fxts.dev/docs/pipe | pipe}, {@link https://fxts.dev/docs/toAsync | toAsync}
  */
-function last<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function last<T extends UniversalIterable<unknown>>(
   iterable: T,
 ): LastReturnType<T>;
 
-function last<A>(iterable: Iterable<A> | AsyncIterable<A>) {
+function last<A>(iterable: UniversalIterable<A>) {
   if (isArray(iterable) || isString(iterable)) {
     return iterable[iterable.length - 1];
   }

--- a/src/max.ts
+++ b/src/max.ts
@@ -1,4 +1,5 @@
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 function sync(iterable: Iterable<number>) {
@@ -46,11 +47,11 @@ async function async(iterable: AsyncIterable<number>) {
  * max([]); // -Infinity
  * ```
  */
-function max<A extends Iterable<number> | AsyncIterable<number>>(
+function max<A extends UniversalIterable<number>>(
   iterable: A,
 ): ReturnValueType<A, number>;
 
-function max(iterable: Iterable<number> | AsyncIterable<number>) {
+function max(iterable: UniversalIterable<number>) {
   if (isIterable(iterable)) {
     return sync(iterable);
   } else if (isAsyncIterable(iterable)) {

--- a/src/min.ts
+++ b/src/min.ts
@@ -1,4 +1,5 @@
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 function sync(iterable: Iterable<number>) {
@@ -47,11 +48,11 @@ async function async(iterable: AsyncIterable<number>) {
  * min([]); // Infinity
  * ```
  */
-function min<A extends Iterable<number> | AsyncIterable<number>>(
+function min<A extends UniversalIterable<number>>(
   iterable: A,
 ): ReturnValueType<A, number>;
 
-function min(iterable: Iterable<number> | AsyncIterable<number>) {
+function min(iterable: UniversalIterable<number>) {
   if (isIterable(iterable)) {
     return sync(iterable);
   } else if (isAsyncIterable(iterable)) {

--- a/src/nth.ts
+++ b/src/nth.ts
@@ -1,5 +1,6 @@
 import IterableInfer from "./types/IterableInfer";
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 function sync<T>(index: number, iterable: Iterable<T>): T | undefined {
@@ -53,11 +54,11 @@ function nth<T>(
   iterable: AsyncIterable<T>,
 ): Promise<T | undefined>;
 
-function nth<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function nth<T extends UniversalIterable<unknown>>(
   index: number,
 ): (iterable: T) => ReturnValueType<T, IterableInfer<T> | undefined>;
 
-function nth<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function nth<T extends UniversalIterable<unknown>>(
   index: number,
   iterable?: T,
 ):

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -1,6 +1,7 @@
 import IterableInfer from "./types/IterableInfer";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 import toArray from "./toArray";
+import { UniversalIterable } from "./types/Utils";
 
 function inner<T>(obj: T, keys: Set<keyof T>) {
   return Object.fromEntries(
@@ -74,10 +75,7 @@ function omit<T extends object, U extends AsyncIterable<keyof T>>(
   iterable: U,
 ): (obj: T) => Promise<Omit<T, IterableInfer<U>>>;
 
-function omit<
-  T extends object,
-  U extends AsyncIterable<keyof T> | Iterable<keyof T>,
->(
+function omit<T extends object, U extends UniversalIterable<keyof T>>(
   iterable: U,
   obj?: T,
 ):

--- a/src/partition.ts
+++ b/src/partition.ts
@@ -3,6 +3,7 @@ import ReturnPartitionType from "./types/ReturnPartitionType";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 import groupBy from "./groupBy";
 import { AsyncFunctionException } from "./_internal/error";
+import { UniversalIterable } from "./types/Utils";
 
 /**
  * Split Iterable/AsyncIterable into two arrays:
@@ -49,11 +50,11 @@ function partition<A, B>(
   iterable: AsyncIterable<A>,
 ): Promise<[A[], A[]]>;
 
-function partition<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function partition<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
 ): (iterable: A) => ReturnPartitionType<A>;
 
-function partition<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function partition<A extends UniversalIterable<unknown>, B>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ):

--- a/src/reduce.ts
+++ b/src/reduce.ts
@@ -2,6 +2,7 @@ import pipe1 from "./pipe1";
 import Arrow from "./types/Arrow";
 import IterableInfer from "./types/IterableInfer";
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 function sync<A, B>(f: (a: B, b: A) => B, acc: B, iterable: Iterable<A>): B {
@@ -98,21 +99,21 @@ function reduce<A, B>(
   iterable: AsyncIterable<A>,
 ): Promise<B>;
 
-function reduce<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function reduce<A extends UniversalIterable<unknown>>(
   f: (
     a: IterableInfer<A>,
     b: IterableInfer<A>,
   ) => IterableInfer<A> | Promise<IterableInfer<A>>,
 ): (iterable: A) => ReturnValueType<A, IterableInfer<A>>;
 
-function reduce<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function reduce<A extends UniversalIterable<unknown>, B>(
   f: (a: B, b: IterableInfer<A>) => B | Promise<B>,
 ): (iterable: A) => ReturnValueType<A, B>;
 
-function reduce<A extends Iterable<unknown> | AsyncIterable<unknown>, B>(
+function reduce<A extends UniversalIterable<unknown>, B>(
   f: (a: B, b: IterableInfer<A>) => B,
-  seed?: B | Iterable<IterableInfer<A>> | AsyncIterable<IterableInfer<A>>,
-  iterable?: Iterable<IterableInfer<A>> | AsyncIterable<IterableInfer<A>>,
+  seed?: B | UniversalIterable<IterableInfer<A>>,
+  iterable?: UniversalIterable<IterableInfer<A>>,
 ):
   | B
   | undefined

--- a/src/size.ts
+++ b/src/size.ts
@@ -1,5 +1,6 @@
 import each from "./each";
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 function sync<A extends Iterable<unknown>>(iterable: A) {
@@ -25,13 +26,11 @@ async function async<A extends AsyncIterable<unknown>>(iterable: A) {
  * await size(toAsync([1, 2, 3, 4])); // 4
  * ```
  */
-function size<A extends Iterable<unknown> | AsyncIterable<unknown>>(
+function size<A extends UniversalIterable<unknown>>(
   iterable: A,
 ): ReturnValueType<A, number>;
 
-function size<A extends Iterable<unknown> | AsyncIterable<unknown>>(
-  iterable: A,
-) {
+function size<A extends UniversalIterable<unknown>>(iterable: A) {
   if (isIterable(iterable)) {
     return sync(iterable);
   }

--- a/src/some.ts
+++ b/src/some.ts
@@ -7,6 +7,7 @@ import { isAsyncIterable, isIterable } from "./_internal/utils";
 import IterableInfer from "./types/IterableInfer";
 import ReturnValueType from "./types/ReturnValueType";
 import Arrow from "./types/Arrow";
+import { UniversalIterable } from "./types/Utils";
 
 /**
  * Returns true if any of the values in Iterable/AsyncIterable pass `f` truth test
@@ -56,15 +57,11 @@ function some<A, B = unknown>(
   iterable: AsyncIterable<A>,
 ): Promise<boolean>;
 
-function some<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B = unknown,
->(f: (a: IterableInfer<A>) => B): (a: A) => ReturnValueType<A, boolean>;
+function some<A extends UniversalIterable<unknown>, B = unknown>(
+  f: (a: IterableInfer<A>) => B,
+): (a: A) => ReturnValueType<A, boolean>;
 
-function some<
-  A extends Iterable<unknown> | AsyncIterable<unknown>,
-  B = unknown,
->(
+function some<A extends UniversalIterable<unknown>, B = unknown>(
   f: (a: IterableInfer<A>) => B,
   iterable?: A,
 ): boolean | Promise<boolean> | ((iterable: A) => ReturnValueType<A, boolean>) {

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -4,6 +4,7 @@ import { isAsyncIterable, isIterable } from "./_internal/utils";
 import isArray from "./isArray";
 import pipe1 from "./pipe1";
 import toArray from "./toArray";
+import { UniversalIterable } from "./types/Utils";
 
 /**
  * Returns an array, sorted according to the comparator `f`, which should accept two values
@@ -31,11 +32,11 @@ function sort<T>(
   iterable: AsyncIterable<T>,
 ): Promise<T[]>;
 
-function sort<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function sort<T extends UniversalIterable<unknown>>(
   f: (a: IterableInfer<T>, b: IterableInfer<T>) => unknown,
 ): (iterable: T) => ReturnValueType<T, IterableInfer<T>[]>;
 
-function sort<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function sort<T extends UniversalIterable<unknown>>(
   f: (a: IterableInfer<T>, b: IterableInfer<T>) => unknown,
   iterable?: T,
 ):

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -3,6 +3,7 @@ import pipe1 from "./pipe1";
 import toArray from "./toArray";
 import IterableInfer from "./types/IterableInfer";
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 /**
@@ -25,11 +26,11 @@ function sortBy<T>(
   iterable: AsyncIterable<T>,
 ): Promise<T[]>;
 
-function sortBy<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function sortBy<T extends UniversalIterable<unknown>>(
   f: (a: IterableInfer<T>) => unknown,
 ): (iterable: T) => ReturnValueType<T, IterableInfer<T>[]>;
 
-function sortBy<T extends Iterable<unknown> | AsyncIterable<unknown>>(
+function sortBy<T extends UniversalIterable<unknown>>(
   f: (a: IterableInfer<T>) => unknown,
   iterable?: T,
 ):

--- a/src/sum.ts
+++ b/src/sum.ts
@@ -1,6 +1,7 @@
 import add from "./add";
 import reduce from "./reduce";
 import ReturnValueType from "./types/ReturnValueType";
+import { UniversalIterable } from "./types/Utils";
 import { isAsyncIterable, isIterable } from "./_internal/utils";
 
 /**
@@ -14,13 +15,9 @@ import { isAsyncIterable, isIterable } from "./_internal/utils";
  * await sum(toAsync(['a', 'b', 'c'])); // 'abc'
  * ```
  */
-function sum<
-  A extends
-    | Iterable<number>
-    | AsyncIterable<number>
-    | Iterable<string>
-    | AsyncIterable<string>,
->(iterable: A): ReturnValueType<A> {
+function sum<A extends UniversalIterable<number> | UniversalIterable<string>>(
+  iterable: A,
+): ReturnValueType<A> {
   if (isIterable(iterable)) {
     return reduce(add, iterable) as ReturnValueType<A>;
   }


### PR DESCRIPTION
I was wondering why you didn't use `UniversalIterable` and `UniversalIterator`.
If there is reason to avoid using it, it would be lovely to explain me why 🙏
