### PR TITLE
Fix/unicode

### DIFF
--- a/src/Lazy/dropRight.ts
+++ b/src/Lazy/dropRight.ts
@@ -5,21 +5,9 @@ import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import concurrent, { isConcurrent } from "./concurrent";
 
-function* stringDropRight(length: number, str: string) {
-  const arr = Array.from(str);
-  for (let i = 0; i < str.length - length; i++) {
-    yield arr[i];
-  }
-}
-
-function* arrayDropRight<T>(length: number, arr: Array<T>) {
-  for (let i = 0; i < arr.length - length; i++) {
-    yield arr[i];
-  }
-}
-
 function* sync<T>(length: number, iterable: Iterable<T>) {
-  const arr = toArray(iterable);
+  const arr =
+    isArray(iterable) || isString(iterable) ? iterable : toArray(iterable);
   for (let i = 0; i < arr.length - length; i++) {
     yield arr[i];
   }
@@ -128,14 +116,6 @@ function dropRight<A extends Iterable<unknown> | AsyncIterable<unknown>>(
 
   if (length < 0) {
     throw new RangeError("'length' must be greater than 0");
-  }
-
-  if (isArray(iterable)) {
-    return arrayDropRight<A>(length, iterable);
-  }
-
-  if (isString(iterable)) {
-    return stringDropRight(length, iterable) as any;
   }
 
   if (isIterable<A>(iterable)) {

--- a/src/Lazy/reverse.ts
+++ b/src/Lazy/reverse.ts
@@ -5,21 +5,9 @@ import { isAsyncIterable, isIterable } from "../_internal/utils";
 import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import concurrent, { isConcurrent } from "./concurrent";
 
-function* stringReverse(str: string) {
-  const arr = Array.from(str);
-  for (let i = arr.length - 1; i >= 0; i--) {
-    yield arr[i];
-  }
-}
-
-function* arrayReverse<T>(arr: Array<T>) {
-  for (let i = arr.length - 1; i >= 0; i--) {
-    yield arr[i];
-  }
-}
-
 function* sync<T>(iterable: Iterable<T>) {
-  const arr = toArray(iterable);
+  const arr =
+    isArray(iterable) || isString(iterable) ? iterable : toArray(iterable);
   for (let i = arr.length - 1; i >= 0; i--) {
     yield arr[i];
   }
@@ -92,14 +80,6 @@ function reverse<T extends Iterable<unknown> | AsyncIterable<unknown>>(
 function reverse<T extends Iterable<unknown> | AsyncIterable<unknown>>(
   iterable: T,
 ) {
-  if (isArray(iterable)) {
-    return arrayReverse(iterable);
-  }
-
-  if (isString(iterable)) {
-    return stringReverse(iterable);
-  }
-
   if (isIterable(iterable)) {
     return sync(iterable);
   }

--- a/src/Lazy/takeRight.ts
+++ b/src/Lazy/takeRight.ts
@@ -6,23 +6,9 @@ import isArray from "../isArray";
 import isString from "../isString";
 import concurrent, { isConcurrent } from "./concurrent";
 
-function* stringTakeRight(length: number, str: string) {
-  const arr = Array.from(str);
-  const index = arr.length - length;
-  for (let i = index; i < arr.length; i++) {
-    if (arr[i]) yield arr[i];
-  }
-}
-
-function* arrayTakeRight<A>(length: number, arr: Array<A>) {
-  const index = arr.length - length;
-  for (let i = index; i < arr.length; i++) {
-    if (arr[i]) yield arr[i];
-  }
-}
-
 function* sync<A>(length: number, iterable: Iterable<A>): IterableIterator<A> {
-  const arr = toArray(iterable);
+  const arr =
+    isArray(iterable) || isString(iterable) ? iterable : toArray(iterable);
   const index = arr.length - length;
   for (let i = index; i < arr.length; i++) {
     if (arr[i]) yield arr[i];
@@ -127,14 +113,6 @@ function takeRight<A extends Iterable<unknown> | AsyncIterable<unknown>>(
     return (iterable: A) => {
       return takeRight(l, iterable as any) as ReturnIterableIteratorType<A>;
     };
-  }
-
-  if (isArray(iterable)) {
-    return arrayTakeRight<A>(l, iterable) as any;
-  }
-
-  if (isString(iterable)) {
-    return stringTakeRight(l, iterable) as any;
   }
 
   if (isIterable<IterableInfer<A>>(iterable)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import sortBy from "./sortBy";
 import sum from "./sum";
 import tap from "./tap";
 import toArray from "./toArray";
+import unicodeToArray from "./unicodeToArray";
 
 export {
   add,
@@ -97,6 +98,7 @@ export {
   sum,
   tap,
   toArray,
+  unicodeToArray,
 };
 
 export * from "./Lazy/index";

--- a/src/unicodeToArray.ts
+++ b/src/unicodeToArray.ts
@@ -1,0 +1,58 @@
+// source: https://github.com/lodash/lodash/blob/master/.internal/unicodeToArray.js
+
+/** Used to compose unicode character classes. */
+const rsAstralRange = "\\ud800-\\udfff";
+const rsComboMarksRange = "\\u0300-\\u036f";
+const reComboHalfMarksRange = "\\ufe20-\\ufe2f";
+const rsComboSymbolsRange = "\\u20d0-\\u20ff";
+const rsComboMarksExtendedRange = "\\u1ab0-\\u1aff";
+const rsComboMarksSupplementRange = "\\u1dc0-\\u1dff";
+const rsComboRange =
+  rsComboMarksRange +
+  reComboHalfMarksRange +
+  rsComboSymbolsRange +
+  rsComboMarksExtendedRange +
+  rsComboMarksSupplementRange;
+const rsVarRange = "\\ufe0e\\ufe0f";
+
+/** Used to compose unicode capture groups. */
+const rsAstral = `[${rsAstralRange}]`;
+const rsCombo = `[${rsComboRange}]`;
+const rsFitz = "\\ud83c[\\udffb-\\udfff]";
+const rsModifier = `(?:${rsCombo}|${rsFitz})`;
+const rsNonAstral = `[^${rsAstralRange}]`;
+const rsRegional = "(?:\\ud83c[\\udde6-\\uddff]){2}";
+const rsSurrPair = "[\\ud800-\\udbff][\\udc00-\\udfff]";
+const rsZWJ = "\\u200d";
+
+/** Used to compose unicode regexes. */
+const reOptMod = `${rsModifier}?`;
+const rsOptVar = `[${rsVarRange}]?`;
+const rsOptJoin = `(?:${rsZWJ}(?:${[rsNonAstral, rsRegional, rsSurrPair].join(
+  "|",
+)})${rsOptVar + reOptMod})*`;
+const rsSeq = rsOptVar + reOptMod + rsOptJoin;
+const rsNonAstralCombo = `${rsNonAstral}${rsCombo}?`;
+const rsSymbol = `(?:${[
+  rsNonAstralCombo,
+  rsCombo,
+  rsRegional,
+  rsSurrPair,
+  rsAstral,
+].join("|")})`;
+
+/** Used to match [string symbols](https://mathiasbynens.be/notes/javascript-unicode). */
+const reUnicode = RegExp(`${rsFitz}(?=${rsFitz})|${rsSymbol + rsSeq}`, "g");
+
+/**
+ * Converts a Unicode `string` to an array.
+ *
+ * @private
+ * @param {string} string The string to convert.
+ * @returns {Array} Returns the converted array.
+ */
+function unicodeToArray(string: string) {
+  return string.match(reUnicode) || [];
+}
+
+export default unicodeToArray;

--- a/src/unicodeToArray.ts
+++ b/src/unicodeToArray.ts
@@ -47,9 +47,10 @@ const reUnicode = RegExp(`${rsFitz}(?=${rsFitz})|${rsSymbol + rsSeq}`, "g");
 /**
  * Converts a Unicode `string` to an array.
  *
- * @private
- * @param {string} string The string to convert.
- * @returns {Array} Returns the converted array.
+ * * @example
+ * * ```ts
+ * *  unicodeToArray('🙇‍♂️🤩😭'); // ['🙇‍♂️','🤩','😭'];
+ * * ```
  */
 function unicodeToArray(string: string) {
   return string.match(reUnicode) || [];


### PR DESCRIPTION
Fixes https://github.com/marpple/FxTS/issues/148

Instead of handling unicode with the `Array.from` function in dropRight (and reverse, takeRight), the `unicodeToArray` function of `lodash.js` is provided, so that the user can directly process the unicode as needed.