### PR TITLE
fix: comment result of `average()` function

### DIFF
--- a/src/average.ts
+++ b/src/average.ts
@@ -10,14 +10,14 @@ import { isAsyncIterable, isIterable } from "./_internal/utils";
  * @example
  * ```ts
  * average([]); // NaN
- * average([1, 2, 3, 4, 5]); // 6
- * await average(toAsync([1, 2, 3, 4, 5])); // 6
+ * average([1, 2, 3, 4, 5]); // 3
+ * await average(toAsync([1, 2, 3, 4, 5])); // 3
  *
  * // with pipe
  * pipe(
  *  [1, 2, 3, 4, 5],
  *  average,
- * ); // 6
+ * ); // 3
  * ```
  *
  * see {@link https://fxts.dev/docs/pipe | pipe}


### PR DESCRIPTION
Thank you for providing a good library.
There was a difference between the test code and the actual annotation, so I fixed it.

[average docs](https://fxts.dev/docs/average)

![image](https://user-images.githubusercontent.com/69495129/205240577-ff847c7e-7565-439c-a982-3f6ea3348f13.png)

```tsx
// average.spec.ts

 it.each([
      [[1, 2, 3, 4, 5], 3],
      [[], NaN],
    ])(
      "should return the average of the given elements",
      function (nums, result) {
        expect(average(nums)).toEqual(result);
      },
    );

    it("should be able to be used as a curried function in the pipeline", function () {
      const res = pipe([1, 2, 3, 4, 5], average);
      expect(res).toEqual(3);
    });
```

Thank you😎

