### PR TITLE
feat: improved type inference of `partition` function

### DIFF
--- a/src/partition.ts
+++ b/src/partition.ts
@@ -42,6 +42,27 @@ import { AsyncFunctionException } from "./_internal/error";
  *
  *  see {@link https://fxts.dev/docs/pipe | pipe}, {@link https://fxts.dev/docs/toAsync | toAsync}
  */
+
+function partition<A, L extends A, R extends A = Exclude<A, L>>(
+  f: (a: A) => a is L,
+  iterable: Iterable<A>,
+): [L[], R[]];
+
+function partition<A, L extends A, R extends A = Exclude<A, L>>(
+  f: (a: A) => a is L,
+  iterable: AsyncIterable<A>,
+): Promise<[L[], R[]]>;
+
+function partition<
+  A extends Iterable<unknown> | AsyncIterable<unknown>,
+  L extends IterableInfer<A>,
+  R = Exclude<IterableInfer<A>, L>,
+>(
+  f: (a: IterableInfer<A>) => a is L,
+): (
+  iterable: A,
+) => A extends AsyncIterable<any> ? Promise<[L[], R[]]> : [L[], R[]];
+
 function partition<A, B>(f: (a: A) => B, iterable: Iterable<A>): [A[], A[]];
 
 function partition<A, B>(

--- a/type-check/partition.test.ts
+++ b/type-check/partition.test.ts
@@ -3,32 +3,53 @@ import { partition, pipe, toAsync } from "../src";
 
 const { checks, check } = Test;
 
-type Res = [(string | number)[], (string | number)[]];
+const res0 = partition((a) => typeof a === "string", []);
+const res1 = partition((a) => a > 3, [0, 1, 2, 3, 4]);
 
-const res1 = partition((a) => typeof a === "string", []);
-const res2: Res = partition(
-  (a) => typeof a === "number",
-  ["3", "4", "5", 1, 2, 3],
-);
-const res3: Res = pipe(
-  ["3", "4", "5", 1, 2, 3],
+type Res1 = [(string | number)[], (string | number)[]];
+const list1 = ["3", "4", "5", 1, 2, 3];
+const res2 = partition((a) => typeof a === "number", list1);
+const res3: Res1 = pipe(
+  list1,
   partition((a) => typeof a === "number"),
 );
 // throw AsyncFunctionException
-const res4: Res = pipe(
-  ["3", "4", "5", 1, 2, 3],
+const res4: Res1 = pipe(
+  list1,
   partition((a) => Promise.resolve(typeof a === "number")),
 );
-const res5: Promise<Res> = pipe(
-  ["3", "4", "5", 1, 2, 3],
+const res5: Promise<Res1> = pipe(
+  list1,
   toAsync,
   partition((a) => Promise.resolve(typeof a === "number")),
 );
 
+type Res2 = [number[], (string | boolean)[]];
+const list2 = ["3", "4", "5", 1, 2, 3, true, false];
+const res6 = partition((a): a is number => typeof a === "number", list2);
+const res7 = pipe(
+  list2,
+  partition((a): a is number => typeof a === "number"),
+);
+const res8 = partition(
+  (a): a is number => typeof a === "number",
+  toAsync(list2),
+);
+const res9 = pipe(
+  list2,
+  toAsync,
+  partition((a): a is number => typeof a === "number"),
+);
+
 checks([
-  check<typeof res1, [never[], never[]], Test.Pass>(),
-  check<typeof res2, Res, Test.Pass>(),
-  check<typeof res3, Res, Test.Pass>(),
-  check<typeof res4, Res, Test.Pass>(),
-  check<typeof res5, Promise<Res>, Test.Pass>(),
+  check<typeof res0, [never[], never[]], Test.Pass>(),
+  check<typeof res1, [number[], number[]], Test.Pass>(),
+  check<typeof res2, Res1, Test.Pass>(),
+  check<typeof res3, Res1, Test.Pass>(),
+  check<typeof res4, Res1, Test.Pass>(),
+  check<typeof res5, Promise<Res1>, Test.Pass>(),
+  check<typeof res6, Res2, Test.Pass>(),
+  check<typeof res7, Res2, Test.Pass>(),
+  check<typeof res8, Promise<Res2>, Test.Pass>(),
+  check<typeof res9, Promise<Res2>, Test.Pass>(),
 ]);


### PR DESCRIPTION
Fixes #181 

Improved type inference of `partition` function when receiving custom typeguard function as an argument.
```ts
const res = partition(
  (a): a is number => typeof a === "number",
  [1, 2, "a", "b", true, false],
);
// As-is
// typeof res == [(number | string | boolean)[], (number | string | boolean)[]]

// To-be
// typeof res == [number[], (string | boolean)[]]
```