### PR TITLE
Feat/180

### DIFF
--- a/.commitlintrc
+++ b/.commitlintrc
@@ -1,3 +1,6 @@
 {
-  extends: ["@commitlint/config-conventional"]
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "header-max-length": [1, 'always', 110]
+  }
 }

--- a/src/Lazy/reject.ts
+++ b/src/Lazy/reject.ts
@@ -53,6 +53,28 @@ import ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
  * see {@link https://fxts.dev/docs/pipe | pipe}, {@link https://fxts.dev/docs/toAsync | toAsync},
  * {@link https://fxts.dev/docs/toArray | toArray}
  */
+
+function reject<A, B extends A>(
+  f: (a: A) => a is B,
+  iterable: Iterable<A>,
+): IterableIterator<Exclude<A, B>>;
+
+function reject<A, B extends A>(
+  f: (a: A) => a is B,
+  iterable: AsyncIterable<A>,
+): AsyncIterableIterator<Exclude<A, B>>;
+
+function reject<
+  A extends Iterable<unknown> | AsyncIterable<unknown>,
+  B extends IterableInfer<A>,
+>(
+  f: (a: IterableInfer<A>) => a is B,
+): (
+  iterable: A,
+) => A extends AsyncIterable<any>
+  ? AsyncIterableIterator<Exclude<IterableInfer<A>, B>>
+  : IterableIterator<Exclude<IterableInfer<A>, B>>;
+
 function reject<A, B = unknown>(
   f: (a: A) => B,
   iterable: Iterable<A>,

--- a/type-check/Lazy/reject.test.ts
+++ b/type-check/Lazy/reject.test.ts
@@ -1,5 +1,5 @@
 import * as Test from "../../src/types/Test";
-import { toAsync, reject, pipe } from "../../src";
+import { isNil, isString, pipe, reject, toAsync } from "../../src";
 
 const { checks, check } = Test;
 
@@ -25,6 +25,20 @@ const res8 = pipe(
   reject(async (a) => a % 2 === 0),
 );
 
+const res9 = reject(isNil, [1, 2, 3, "4", "5", "6", null, undefined]);
+const res10 = reject(isNil, toAsync([1, 2, 3, "4", "5", "6", null, undefined]));
+const res11 = pipe(
+  [1, 2, 3, "4", "5", "6", null, undefined],
+  reject(isNil),
+  reject(isString),
+);
+const res12 = pipe(
+  [1, 2, 3, "4", "5", "6", null, undefined],
+  toAsync,
+  reject(isNil),
+  reject(isString),
+);
+
 checks([
   check<typeof res1, IterableIterator<number>, Test.Pass>(),
   check<typeof res2, IterableIterator<number>, Test.Pass>(),
@@ -35,4 +49,9 @@ checks([
   check<typeof res6, IterableIterator<number>, Test.Pass>(),
   check<typeof res7, AsyncIterableIterator<number>, Test.Pass>(),
   check<typeof res8, AsyncIterableIterator<number>, Test.Pass>(),
+
+  check<typeof res9, IterableIterator<number | string>, Test.Pass>(),
+  check<typeof res10, AsyncIterableIterator<number | string>, Test.Pass>(),
+  check<typeof res11, IterableIterator<number>, Test.Pass>(),
+  check<typeof res12, AsyncIterableIterator<number>, Test.Pass>(),
 ]);


### PR DESCRIPTION
Fixes #180

Improved type inference of `reject` function when receiving custom typeguard function as an argument.
```ts
const res = pipe(
  [1, 2, 3, "4", "5", "6", null, undefined],
  reject(isNil), // (a): a is null | undefined => a == null
  reject(isString), // (a): a is string => typeof a === "string"
  toArray,
);
// As-is
// typeof res == (number, string | null | undefined)[]

// To-be
// typeof res == number[]
```