### PR TITLE
Fix: length must not be undefined

### DIFF
--- a/src/Lazy/concurrent.ts
+++ b/src/Lazy/concurrent.ts
@@ -92,6 +92,10 @@ function concurrent<A>(
   if (length <= 0) {
     throw new RangeError("'length' must be over 0");
   }
+    
+  if (!length) {
+      throw new TypeError("'length' must be type of number");
+  }
 
   if (!isAsyncIterable(iterable)) {
     throw new TypeError("'iterable' must be type of AsyncIterable");

--- a/src/Lazy/concurrent.ts
+++ b/src/Lazy/concurrent.ts
@@ -89,12 +89,8 @@ function concurrent<A>(
     throw new RangeError("'length' cannot be infinite");
   }
 
-  if (length <= 0) {
-    throw new RangeError("'length' must be over 0");
-  }
-    
-  if (!length) {
-      throw new TypeError("'length' must be type of number");
+  if (!Number.isFinite(length) || length <= 0) {
+    throw new RangeError("'length' must be positive integer");
   }
 
   if (!isAsyncIterable(iterable)) {

--- a/src/Lazy/concurrent.ts
+++ b/src/Lazy/concurrent.ts
@@ -85,10 +85,6 @@ function concurrent<A>(
     };
   }
 
-  if (length === Infinity) {
-    throw new RangeError("'length' cannot be infinite");
-  }
-
   if (!Number.isFinite(length) || length <= 0) {
     throw new RangeError("'length' must be positive integer");
   }


### PR DESCRIPTION
Concurrent allows undefined values for its length parameter. It was my mistake, but it caused Node to consume all CPU resources. Moreover, it didn't throw any errors, which wasted time trying to find the cause of the issue. Therefore, I strongly believe that this issue must be fixed.

Fixes #
