### PR TITLE
refactor: change isEmpty logic

### DIFF
--- a/src/isEmpty.ts
+++ b/src/isEmpty.ts
@@ -1,62 +1,39 @@
+import isArray from "./isArray";
+import isNil from "./isNil";
+
 /**
  * Returns true if the given value is empty value, false otherwise.
  *
  * @example
  * ```ts
- * isEmpty(1); // false
- * isEmpty(0); // false
- * isEmpty(false); // false
- * isEmpty(true); // false
- * isEmpty(new Date()); // false
- * isEmpty(undefined); // true
- * isEmpty(null); // true
+ * isEmpty({}) // true
+ * isEmpty([]) // true
+ * isEmpty(null) // true
+ * isEmpty(undefined) // true
+ * isEmpty("") // true
  *
- * isEmpty({}); // true
- * isEmpty({a:1}); // false
- *
- * isEmpty([]); // true
- * isEmpty([1]); // false
- *
- * isEmpty(""); // true
- * isEmpty("a"); // false
- *
- * isEmpty(function(){}); // false
- * isEmpty(Symbol("")); // false
+ * isEmpty(0) // false
+ * isEmpty(false) // false
+ * isEmpty(function(){}) // false
+ * isEmpty(Symbol("")) // false
+ * isEmpty(new Date()) // false
  * ```
  */
-function isEmpty(value: unknown): boolean {
-  if (typeof value === "number" || typeof value === "boolean") {
-    return false;
-  }
+export const isEmpty = (value: unknown): boolean => {
+  if (isNil(value)) return true; // if value is null or undefined.
 
-  if (typeof value === "undefined" || value === null) {
-    return true;
-  }
+  if (
+    typeof value === "object" &&
+    (value as object)["constructor"] === Object &&
+    Object.getOwnPropertyNames(value).length === 0
+  )
+    return true; // if value is a literal object and have no property or method.
 
-  if (value instanceof Date) {
-    return false;
-  }
+  if (isArray(value) && value.length === 0) return true; // if value have no item.
 
-  if (typeof value === "function") {
-    return false;
-  }
-
-  if (value instanceof Object && !Object.keys(value).length) {
-    return true;
-  }
-
-  if (Array.isArray(value)) {
-    if (value.length === 0) {
-      return true;
-    }
-    return false;
-  }
-
-  if (value === "") {
-    return true;
-  }
+  if (value === "") return true;
 
   return false;
-}
+};
 
 export default isEmpty;


### PR DESCRIPTION
if value is object, it have to literal object and have no method and property.
if value is instance of class, isEmpty always return true. ex) Date, Custom Class, .....
- but array instance is considered to have item or not.