### PR TITLE
feat: change `reduce` behavior, when empty iterable

### DIFF
--- a/src/every.ts
+++ b/src/every.ts
@@ -58,7 +58,12 @@ function every<
     return pipe(
       map(f, iterable),
       takeUntil(not),
-      reduce((a, b) => a && b),
+      (acc) =>
+        reduce(
+          (a: boolean, b: boolean) => a && b,
+          true,
+          acc as Iterable<boolean>,
+        ),
       (a) => a ?? true,
       Boolean,
     );
@@ -68,7 +73,12 @@ function every<
     return pipe(
       map(f, iterable),
       takeUntil(not),
-      reduce((a, b) => a && b),
+      (acc) =>
+        reduce(
+          (a: boolean, b: boolean) => a && b,
+          true,
+          acc as AsyncIterable<boolean>,
+        ),
       (a) => a ?? true,
       Boolean,
     );

--- a/src/join.ts
+++ b/src/join.ts
@@ -10,7 +10,11 @@ type ReturnJoinType<T extends Iterable<unknown> | AsyncIterable<unknown>> =
     : never;
 
 function sync<A>(sep: string, iterable: Iterable<A>) {
-  const res = reduce((a: string, b) => `${a}${sep}${b}`, iterable);
+  const res = reduce(
+    (a: string, b) => (a == "" ? `${b}` : `${a}${sep}${b}`),
+    "",
+    iterable,
+  );
   if (res == null) {
     return "";
   }
@@ -19,7 +23,11 @@ function sync<A>(sep: string, iterable: Iterable<A>) {
 }
 
 function async<A>(sep: string, iterable: AsyncIterable<A>) {
-  return reduce((a: string, b) => `${a}${sep}${b}`, iterable).then((res) => {
+  return reduce(
+    (a: string, b) => (a == "" ? `${b}` : `${a}${sep}${b}`),
+    "",
+    iterable,
+  ).then((res) => {
     if (res == null) {
       return "";
     }

--- a/src/some.ts
+++ b/src/some.ts
@@ -78,7 +78,12 @@ function some<
     return pipe(
       map(f, iterable),
       takeUntil(identity),
-      reduce((a, b) => a || b),
+      (acc) =>
+        reduce(
+          (a: boolean, b: boolean) => a || b,
+          false,
+          acc as Iterable<boolean>,
+        ),
       Boolean,
     );
   }
@@ -87,7 +92,12 @@ function some<
     return pipe(
       map(f, iterable),
       takeUntil(identity),
-      reduce((a, b) => a || b),
+      (acc) =>
+        reduce(
+          (a: boolean, b: boolean) => a || b,
+          false,
+          acc as AsyncIterable<boolean>,
+        ),
       Boolean,
     );
   }

--- a/test/reduce.spec.ts
+++ b/test/reduce.spec.ts
@@ -9,8 +9,8 @@ describe("reduce", function () {
       expect(reduce((a, b) => a + b, "seed", [])).toEqual("seed");
     });
 
-    it("should return 'undefined' when the given `iterable` is an empty array and initial value is absent", function () {
-      expect(reduce((a, b) => a + b, [])).toBeUndefined();
+    it("should be occured error when the given `iterable` is an empty array and initial value is absent", function () {
+      expect(() => reduce((a) => a, [])).toThrow();
     });
 
     it("should work given it is initial value", function () {

--- a/type-check/reduce.test.ts
+++ b/type-check/reduce.test.ts
@@ -3,7 +3,7 @@ import * as Test from "../src/types/Test";
 
 const { checks, check } = Test;
 
-const res1 = reduce((a, b) => a + b, []);
+const res1 = reduce((a) => a, []);
 const res2 = reduce((a, b) => a + b, "seed", []);
 const res3 = reduce((a, b) => a + b, 0, [1, 2, 3]);
 const res4 = reduce((a, b) => a + b, [1, 2, 3]);
@@ -52,7 +52,7 @@ const res16 = pipe(
 );
 
 checks([
-  check<typeof res1, undefined, Test.Pass>(),
+  check<typeof res1, never, Test.Pass>(),
   check<typeof res2, "seed", Test.Pass>(),
   check<typeof res3, number, Test.Pass>(),
   check<typeof res4, number, Test.Pass>(),


### PR DESCRIPTION
Fixes #235 
