### PR TITLE
fix(reduce): better type and docs for `reduce` (#240)

### DIFF
--- a/src/reduce.ts
+++ b/src/reduce.ts
@@ -71,7 +71,6 @@ async function async<T, Acc>(
  *
  * {@link https://github.com/marpple/FxTS/issues/239 | #related issue}
  *
- * Asynchronous things don't matter.
  *
  * ```ts
  * await pipe(


### PR DESCRIPTION
At first I mentioned`R` but more describing `Acc` would be better.

- Change type `A`,`B` into `T`, `Acc` for `reduce`
- Give proper value name for `acc`, `value` instead of `a`, `b`
- Add example with explicit seed
- Add `@typeParam` for [tsdoc](https://tsdoc.org/pages/tags/typeparam/) support

Fixes #240
