### PR TITLE
feat: key support bigint

### DIFF
--- a/src/types/Key.ts
+++ b/src/types/Key.ts
@@ -1,3 +1,3 @@
-type Key = string | symbol | number;
+type Key = string | symbol | number | bigint;
 
 export default Key;


### PR DESCRIPTION
Fixes #

Bigint can be assigned as a key to an object, so add it to the Key type.