### PR TITLE
test: exclude non-deterministic tests for `setTimeout`

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,5 +5,4 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   testMatch: [path.join(__dirname, "test/**/*.spec.ts")],
-  maxWorkers: 1,
 };

--- a/test/Lazy/append.spec.ts
+++ b/test/Lazy/append.spec.ts
@@ -9,7 +9,7 @@ import {
   toAsync,
 } from "../../src/index";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("append", function () {
   describe("sync", function () {
@@ -43,8 +43,6 @@ describe("append", function () {
     });
 
     it("should be appended sequentially", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 3000);
       let chainedPromise: Promise<void | number> = Promise.resolve();
       const res = await pipe(
         toAsync(range(1, 4)),
@@ -65,13 +63,10 @@ describe("append", function () {
           ),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
     }, 3050);
 
     it("should be appended concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
       const res = await pipe(
         toAsync([1, 2, 3]),
         map((a) => delay(1000, a)),
@@ -81,7 +76,6 @@ describe("append", function () {
         concurrent(3),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
     }, 1050);
 

--- a/test/Lazy/chunk.spec.ts
+++ b/test/Lazy/chunk.spec.ts
@@ -10,7 +10,7 @@ import {
   toAsync,
 } from "../../src/index";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 const expected = [
   [1, 2, 3],
@@ -60,8 +60,6 @@ describe("chunk", function () {
     });
 
     it("should be chunked after concurrent", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 600);
       const res = await pipe(
         toAsync(range(1, 12)),
         map((a) => delay(100, a)),
@@ -69,13 +67,10 @@ describe("chunk", function () {
         chunk(3),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual(expected);
     }, 650);
 
     it("should be chunked after concurrent with filter", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
       const res = await pipe(
         toAsync(range(1, 21)),
         map((a) => delay(100, a)),
@@ -85,13 +80,10 @@ describe("chunk", function () {
         toArray,
       );
       const expected: number[][] = [[2, 4, 6], [8, 10, 12], [14, 16, 18], [20]];
-      expect(fn).toBeCalled();
       expect(res).toEqual(expected);
     }, 1050);
 
     it("should be chunked before concurrent", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
       const res = await pipe(
         toAsync(range(1, 21)),
         map((a) => delay(100, a)),
@@ -101,7 +93,6 @@ describe("chunk", function () {
         toArray,
       );
       const expected: number[][] = [[2, 4, 6], [8, 10, 12], [14, 16, 18], [20]];
-      expect(fn).toBeCalled();
       expect(res).toEqual(expected);
     }, 1050);
 

--- a/test/Lazy/concat.spec.ts
+++ b/test/Lazy/concat.spec.ts
@@ -8,7 +8,7 @@ import {
   toAsync,
 } from "../../src/index";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("concat", function () {
   describe("sync", function () {
@@ -25,8 +25,6 @@ describe("concat", function () {
 
   describe("async", function () {
     it("should be concatenated given two 'AsyncIterable'", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 4000);
       const res = await pipe(
         [
           map((a) => delay(1000, a), toAsync([1, 2])),
@@ -35,13 +33,10 @@ describe("concat", function () {
         ([a, b]) => concat(a, b),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4]);
     }, 4050);
 
     it("should be concatenated given two 'AsyncIterable' concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 3000);
       const res = await pipe(
         [
           map((a) => delay(1000, a), toAsync([1, 2, 3])),
@@ -51,7 +46,6 @@ describe("concat", function () {
         concurrent(2),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
     }, 3050);
 

--- a/test/Lazy/concurrent.spec.ts
+++ b/test/Lazy/concurrent.spec.ts
@@ -8,12 +8,9 @@ import {
   range,
   toAsync,
 } from "../../src/index";
-import { callFuncAfterTime } from "../utils";
 
 describe("concurrent", function () {
   it("should be consumed 'AsyncIterable' concurrently", async function () {
-    const fn = jest.fn();
-    callFuncAfterTime(fn, 2000);
     const res = concurrent(
       2,
       toAsync(
@@ -29,14 +26,10 @@ describe("concurrent", function () {
     for await (const item of res) {
       acc.push(item);
     }
-    expect(fn).toBeCalled();
     expect(acc).toEqual([1, 2, 3, 4]);
   }, 2050);
 
   it("should be able to be used as a curried function in the pipeline", async function () {
-    const fn = jest.fn();
-    callFuncAfterTime(fn, 500);
-
     const iter = pipe(
       toAsync(range(1, 101)),
       map((a) => delay(100, a)),
@@ -56,13 +49,10 @@ describe("concurrent", function () {
       iter.next(),
     ]).then((arr) => arr.map((a) => a.value));
 
-    expect(fn).toBeCalled();
     expect(arr).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   }, 550);
 
   it("should be affected only one concurrent below it, when nested concurrent", async function () {
-    let fn: jest.Mock<any, any>;
-    fn = jest.fn();
     let concurrent10Count = 0;
     let concurrent2Count = 0;
 
@@ -77,33 +67,23 @@ describe("concurrent", function () {
       concurrent(2),
     );
 
-    callFuncAfterTime(fn, 300);
     await iter.next();
     await iter.next();
-    expect(fn).toBeCalled();
     expect(concurrent2Count).toEqual(4);
     expect(concurrent10Count).toEqual(10);
 
-    fn = jest.fn();
-    callFuncAfterTime(fn, 200);
     await iter.next();
     await iter.next();
-    expect(fn).toBeCalled();
     expect(concurrent2Count).toEqual(8);
     expect(concurrent10Count).toEqual(10);
 
-    fn = jest.fn();
-    callFuncAfterTime(fn, 300);
     await iter.next();
     await iter.next();
-    expect(fn).toBeCalled();
     expect(concurrent2Count).toEqual(12);
     expect(concurrent10Count).toEqual(20);
   }, 850);
 
   it("should return IteratorReturnResult after all consuming 'AsyncIterable'", async function () {
-    const fn = jest.fn();
-    callFuncAfterTime(fn, 1000);
     const iter = concurrent(
       2,
       toAsync(
@@ -121,7 +101,6 @@ describe("concurrent", function () {
       { value: v4, done: d4 },
     ] = await Promise.all([iter.next(), iter.next(), iter.next(), iter.next()]);
 
-    expect(fn).toBeCalled();
     expect(v1).toEqual(1);
     expect(d1).toEqual(false);
     expect(v2).toEqual(2);
@@ -133,8 +112,6 @@ describe("concurrent", function () {
   }, 1050);
 
   it("should be able to handle an error when working concurrent", async function () {
-    const fn = jest.fn();
-    callFuncAfterTime(fn, 2000);
     const res = concurrent(
       2,
       toAsync(
@@ -158,7 +135,6 @@ describe("concurrent", function () {
     } catch (err) {
       expect(err).toEqual("err");
     }
-    expect(fn).toBeCalled();
     expect(acc).toEqual([1, 2, 3]);
   }, 2050);
 });

--- a/test/Lazy/cycle.spec.ts
+++ b/test/Lazy/cycle.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "../../src";
 import { Concurrent } from "../../src/Lazy/concurrent";
 import cycle from "../../src/Lazy/cycle";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("cycle", function () {
   describe("sync", function () {
@@ -77,9 +77,6 @@ describe("cycle", function () {
     });
 
     it("should be repeated concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 900);
-
       const res = await pipe(
         toAsync(
           (function* () {
@@ -97,7 +94,6 @@ describe("cycle", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
     }, 950);
 

--- a/test/Lazy/difference.spec.ts
+++ b/test/Lazy/difference.spec.ts
@@ -1,7 +1,7 @@
 import { delay, map, pipe, toArray, toAsync } from "../../src";
 import concurrent, { Concurrent } from "../../src/Lazy/concurrent";
 import difference from "../../src/Lazy/difference";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("difference", function () {
   describe("sync", function () {
@@ -53,9 +53,6 @@ describe("difference", function () {
     });
 
     it("should be handled concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 900);
-
       const res = await pipe(
         [1, 2, 3, 4, 5, 6, 7, 8, 9],
         toAsync,
@@ -65,7 +62,6 @@ describe("difference", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 6, 7, 8, 9]);
     }, 950);
 

--- a/test/Lazy/drop.spec.ts
+++ b/test/Lazy/drop.spec.ts
@@ -9,7 +9,7 @@ import {
   toAsync,
 } from "../../src/index";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("drop", function () {
   describe("sync", function () {
@@ -61,8 +61,6 @@ describe("drop", function () {
     });
 
     it("should be discarded elements by length concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 400);
       const res = await pipe(
         toAsync([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
         map((a) => delay(100, a)),
@@ -71,7 +69,6 @@ describe("drop", function () {
         concurrent(3),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([6, 8, 10]);
     }, 450);
 

--- a/test/Lazy/dropRight.spec.ts
+++ b/test/Lazy/dropRight.spec.ts
@@ -9,7 +9,7 @@ import {
   toAsync,
 } from "../../src/index";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("dropRight", function () {
   describe("sync", function () {
@@ -69,8 +69,6 @@ describe("dropRight", function () {
     });
 
     it("should be discarded elements by length concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 400);
       const res = await pipe(
         toAsync([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
         map((a) => delay(100, a)),
@@ -79,7 +77,6 @@ describe("dropRight", function () {
         concurrent(3),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([2, 4, 6]);
     }, 450);
 

--- a/test/Lazy/dropUntil.spec.ts
+++ b/test/Lazy/dropUntil.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "../../src";
 import { AsyncFunctionException } from "../../src/_internal/error";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("dropUntil", function () {
   describe("sync", function () {
@@ -89,8 +89,6 @@ describe("dropUntil", function () {
     });
 
     it("should be dropped elements concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1500);
       const res = await pipe(
         [1, 2, 3, 4, 5, 1, 2],
         toAsync,
@@ -100,14 +98,10 @@ describe("dropUntil", function () {
         concurrent(3),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([11]);
     }, 1550);
 
     it("should be controlled the order when concurrency", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 2000);
-
       const res = await pipe(
         toAsync(
           (function* () {
@@ -127,7 +121,6 @@ describe("dropUntil", function () {
         concurrent(5),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([8, 9]);
     }, 2050);
 

--- a/test/Lazy/dropWhile.spec.ts
+++ b/test/Lazy/dropWhile.spec.ts
@@ -10,7 +10,7 @@ import {
   toAsync,
 } from "../../src/index";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("dropWhile", function () {
   describe("sync", function () {
@@ -77,8 +77,6 @@ describe("dropWhile", function () {
     });
 
     it("should be dropped elements concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 400);
       const res = await pipe(
         toAsync([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
         map((a) => delay(100, a)),
@@ -87,14 +85,10 @@ describe("dropWhile", function () {
         concurrent(3),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([6, 8, 10]);
     }, 450);
 
     it("should be controlled the order when concurrency", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 2000);
-
       const res = await pipe(
         toAsync(
           (function* () {
@@ -114,7 +108,6 @@ describe("dropWhile", function () {
         concurrent(5),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([7, 8, 1, 10]);
     }, 2050);
 

--- a/test/Lazy/filter.spec.ts
+++ b/test/Lazy/filter.spec.ts
@@ -11,7 +11,7 @@ import {
   toAsync,
 } from "../../src/index";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 const mod = (a: number) => a % 2 === 0;
 const modAsync = async (a: number) => a % 2 === 0;
@@ -160,9 +160,6 @@ describe("filter", function () {
     }, 1050);
 
     it("should be having all elements when all elements are not filtered", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
-
       const res = await pipe(
         toAsync(range(1, 20)),
         filter(() => delay(100, true)),
@@ -170,16 +167,12 @@ describe("filter", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
       ]);
     }, 1050);
 
     it("should be filtered by the callback 'take' - 'filter' - 'concurrent'", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 2000);
-
       const res = await pipe(
         toAsync(range(1, 21)),
         take(10),
@@ -188,14 +181,10 @@ describe("filter", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([2, 4, 6, 8, 10]);
     }, 2050);
 
     it("should be filtered by the callback 'filter' - 'take' - 'concurrent'", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
-
       const res = await pipe(
         toAsync(range(1, 51)),
         filter((a) => delay(500, a % 2 === 0)),
@@ -204,14 +193,10 @@ describe("filter", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
     }, 1050);
 
     it("should be filtered by the callback 'map' - 'filter' - 'concurrent'", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
-
       const res = await pipe(
         toAsync(range(1, 21)),
         map((a) => delay(500, a + 10)),
@@ -220,14 +205,10 @@ describe("filter", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([12, 14, 16, 18, 20, 22, 24, 26, 28, 30]);
     }, 1050);
 
     it("should be filtered by the callback 'map' - 'filter' - 'concurrent' - 'take'", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
-
       const res = await pipe(
         toAsync(range(1, 10)),
         map((a) => delay(500, a)),
@@ -237,7 +218,6 @@ describe("filter", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([...range(1, 9)]);
     }, 1050);
 
@@ -284,8 +264,6 @@ describe("filter", function () {
     });
 
     it("should be consumed 'AsyncIterable' as many times as called with 'next'", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 2000);
       const iterator = toAsync(range(1, 21));
       const res = pipe(
         iterator,
@@ -299,7 +277,6 @@ describe("filter", function () {
       const { value: v3 } = await res.next();
       const { value: v4 } = await res.next();
       const { value: v5 } = await res.next(); // 10
-      expect(fn).toBeCalled();
       expect(v1).toEqual(2);
       expect(v2).toEqual(4);
       expect(v3).toEqual(6);

--- a/test/Lazy/flat.spec.ts
+++ b/test/Lazy/flat.spec.ts
@@ -12,7 +12,7 @@ import {
   toAsync,
 } from "../../src/index";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("flat", function () {
   describe("sync", function () {
@@ -65,8 +65,6 @@ describe("flat", function () {
     });
 
     it("should be flattened concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
       const iterator = toAsync([
         [1],
         [2],
@@ -93,7 +91,6 @@ describe("flat", function () {
       const { value: v4 } = await res.next();
       const { value: v5 } = await res.next();
       const { value: v6 } = await res.next();
-      expect(fn).toBeCalled();
       expect(v1).toEqual(1);
       expect(v2).toEqual(2);
       expect(v3).toEqual(3);
@@ -234,9 +231,7 @@ describe("flat", function () {
     it.each(testParameters)(
       "should be flattened concurrently",
       async ({ timeout, input, depth, size, expected }: FlatTest) => {
-        const fn = jest.fn();
         jest.setTimeout(timeout + 100);
-        callFuncAfterTime(fn, timeout);
 
         const res = await pipe(
           toAsync(input),
@@ -246,15 +241,11 @@ describe("flat", function () {
           toArray,
         );
 
-        expect(fn).toBeCalled();
         expect(res).toEqual(expected);
       },
     );
 
     it("should be flattened concurrently with chuck", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
-
       const res = await pipe(
         toAsync(range(1, 7)),
         map((a) => delay(500, a)),
@@ -264,7 +255,6 @@ describe("flat", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
     }, 1050);
 

--- a/test/Lazy/intersection.spec.ts
+++ b/test/Lazy/intersection.spec.ts
@@ -1,6 +1,6 @@
 import { delay, intersection, map, pipe, toArray, toAsync } from "../../src";
 import concurrent, { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("intersection", function () {
   describe("sync", function () {
@@ -52,9 +52,6 @@ describe("intersection", function () {
     });
 
     it("should be handled concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 900);
-
       const res = await pipe(
         [1, 2, 3, 4, 5, 6, 7, 8, 9],
         toAsync,
@@ -64,7 +61,6 @@ describe("intersection", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([3, 4, 5]);
     }, 950);
 

--- a/test/Lazy/prepend.spec.ts
+++ b/test/Lazy/prepend.spec.ts
@@ -8,7 +8,6 @@ import {
   toArray,
   toAsync,
 } from "../../src/index";
-import { callFuncAfterTime } from "../utils";
 
 describe("prepend", function () {
   describe("sync", function () {
@@ -47,9 +46,7 @@ describe("prepend", function () {
       expect(res).toEqual([1, 2, 3, 4]);
     });
 
-    it("should be prepened the given element sequentially", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 3000);
+    it("should be prepend the given element sequentially", async function () {
       let chainedPromise: Promise<number | void> = Promise.resolve();
       const res = await pipe(
         toAsync(range(4, 7)),
@@ -70,13 +67,10 @@ describe("prepend", function () {
           ),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
     }, 3050);
 
-    it("should be prepened the given element concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
+    it("should be prepend the given element concurrently", async function () {
       const res = await pipe(
         toAsync([4, 5, 6]),
         map((a) => delay(1000, a)),
@@ -86,13 +80,10 @@ describe("prepend", function () {
         concurrent(3),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
     }, 1050);
 
     it("should be able to be used as a curried function in the pipeline", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
       const res = await pipe(
         toAsync([4, 5, 6]),
         map((a) => delay(1000, a)),
@@ -102,7 +93,6 @@ describe("prepend", function () {
         concurrent(3),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 3, 4, 5, 6]);
     }, 1050);
 

--- a/test/Lazy/reverse.spec.ts
+++ b/test/Lazy/reverse.spec.ts
@@ -1,6 +1,6 @@
 import { delay, filter, map, pipe, reverse, toArray, toAsync } from "../../src";
 import concurrent, { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("reverse", function () {
   describe("sync", function () {
@@ -43,8 +43,6 @@ describe("reverse", function () {
     });
 
     it("should be reversed elements concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 400);
       const res = await pipe(
         toAsync([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
         map((a) => delay(100, a)),
@@ -53,7 +51,6 @@ describe("reverse", function () {
         concurrent(3),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([10, 8, 6, 4, 2]);
     }, 450);
 

--- a/test/Lazy/scan.spec.ts
+++ b/test/Lazy/scan.spec.ts
@@ -1,7 +1,7 @@
 import { delay, map, pipe, range, toArray, toAsync } from "../../src";
 import concurrent, { Concurrent } from "../../src/Lazy/concurrent";
 import scan from "../../src/Lazy/scan";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("scan", function () {
   describe("sync", function () {
@@ -96,9 +96,6 @@ describe("scan", function () {
     });
 
     it("should be handled concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 600);
-
       const res = await pipe(
         [1, 2, 3, 4, 5, 6, 7, 8, 9],
         toAsync,
@@ -108,14 +105,10 @@ describe("scan", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 1, 2, 6, 24, 120, 720, 5040, 40320, 362880]);
     }, 650);
 
     it("should be handled concurrently without seed", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 600);
-
       const res = await pipe(
         [1, 2, 3, 4, 5, 6, 7, 8, 9],
         toAsync,
@@ -125,7 +118,6 @@ describe("scan", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([1, 2, 6, 24, 120, 720, 5040, 40320, 362880]);
     }, 650);
 

--- a/test/Lazy/split.spec.ts
+++ b/test/Lazy/split.spec.ts
@@ -9,7 +9,7 @@ import {
   toAsync,
 } from "../../src";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("split", function () {
   describe("sync", function () {
@@ -105,9 +105,6 @@ describe("split", function () {
     });
 
     it("should be controlled the order when concurrency", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
-
       const res = await pipe(
         toAsync(
           (function* () {
@@ -127,14 +124,10 @@ describe("split", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual(["1", "2", "3", "4", "5"]);
     }, 1050);
 
     it("should be consumed concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
-
       const res = await pipe(
         toAsync("1,2,3,4,5,6,7,8,9,10"),
         split(","),
@@ -145,7 +138,6 @@ describe("split", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([2, 4, 6, 8, 10]);
     }, 1050);
   });

--- a/test/Lazy/takeRight.spec.ts
+++ b/test/Lazy/takeRight.spec.ts
@@ -10,7 +10,7 @@ import {
   toAsync,
 } from "../../src/index";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("takeRight", function () {
   describe("sync", function () {
@@ -104,8 +104,6 @@ describe("takeRight", function () {
     });
 
     it("should be able to take the element concurrently", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 400);
       const res = await pipe(
         toAsync([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
         map((a) => delay(100, a)),
@@ -114,7 +112,6 @@ describe("takeRight", function () {
         concurrent(3),
         toArray,
       );
-      expect(fn).toBeCalled();
       expect(res).toEqual([6, 8, 10]);
     }, 450);
 

--- a/test/Lazy/zip.spec.ts
+++ b/test/Lazy/zip.spec.ts
@@ -8,7 +8,7 @@ import {
   zip,
 } from "../../src/index";
 import { Concurrent } from "../../src/Lazy/concurrent";
-import { callFuncAfterTime, generatorMock } from "../utils";
+import { generatorMock } from "../utils";
 
 describe("zip", function () {
   describe("sync", function () {
@@ -187,9 +187,6 @@ describe("zip", function () {
     });
 
     it("should be zipped sequentially", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 4000);
-
       const res = await pipe(
         toAsync([5, 6, 7, 8]),
         map((nums) => delay(1000, nums)),
@@ -197,7 +194,6 @@ describe("zip", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([
         [1, 5],
         [2, 6],
@@ -207,9 +203,6 @@ describe("zip", function () {
     }, 4050);
 
     it("should be zipped concurrently: zip - map", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
-
       const res = await pipe(
         toAsync([5, 6, 7, 8]),
         zip([1, 2, 3, 4]),
@@ -218,7 +211,6 @@ describe("zip", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([
         [1, 5],
         [2, 6],
@@ -228,9 +220,6 @@ describe("zip", function () {
     }, 1050);
 
     it("should be zipped concurrently: map - zip", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
-
       const res = await pipe(
         toAsync([5, 6, 7, 8]),
         map((nums) => delay(1000, nums)),
@@ -239,7 +228,6 @@ describe("zip", function () {
         toArray,
       );
 
-      expect(fn).toBeCalled();
       expect(res).toEqual([
         [1, 5],
         [2, 6],

--- a/test/tap.spec.ts
+++ b/test/tap.spec.ts
@@ -1,5 +1,4 @@
 import { delay, map, pipe, range, tap, toArray, toAsync } from "../src";
-import { callFuncAfterTime } from "./utils";
 
 describe("tap", function () {
   describe("sync", function () {
@@ -28,18 +27,18 @@ describe("tap", function () {
 
   describe("async", function () {
     it("should return the received argument as it is", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 1000);
       const res = await tap((a) => delay(1000, a), 10);
-      expect(fn).toBeCalled();
       expect(res).toEqual(10);
     }, 1050);
 
     it("should support asynchronous when curried.", async function () {
-      const fn = jest.fn();
-      callFuncAfterTime(fn, 500);
-      await pipe(range(5), toAsync, map(tap(() => delay(100))), toArray);
-      expect(fn).toBeCalled();
-    });
+      const res = await pipe(
+        range(5),
+        toAsync,
+        map(tap(() => delay(100))),
+        toArray,
+      );
+      expect(res).toEqual([0, 1, 2, 3, 4]);
+    }, 550);
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,9 +1,3 @@
-import type Arrow from "../src/types/Arrow";
-
-export const callFuncAfterTime = (callback: Arrow, time = 1000) => {
-  setTimeout(callback, time);
-};
-
 export const generatorMock = (cnt = 10): AsyncIterableIterator<number> => {
   let concurrent: any;
 


### PR DESCRIPTION
In the concurrent test, we test for the maximum time and
We also tested the minimum time,

The setTimeout behavior for minimum time tests intermittently does not work as we intended. This seems to be related to the fact that the setTimeout callback does not work immediately at the originally specified time.


Testing for maximum time is important, so avoid testing for minimum time.