### PR TITLE
fix: dropUntil.ts example

### DIFF
--- a/src/Lazy/dropUntil.ts
+++ b/src/Lazy/dropUntil.ts
@@ -70,10 +70,10 @@ function async<A, B>(
  *
  * @example
  * ```ts
- * const iter = dropUntil((a) => a < 3, [1, 2, 3, 4, 5, 1, 2]);
- * iter.next(); // {done:false, value: 3}
- * iter.next(); // {done:false, value: 4}
+ * const iter = dropUntil((a) => a > 3, [1, 2, 3, 4, 5, 1, 2]);
  * iter.next(); // {done:false, value: 5}
+ * iter.next(); // {done:false, value: 1}
+ * iter.next(); // {done:false, value: 2}
  *
  * // with pipe
  * pipe(


### PR DESCRIPTION
## As-Is
```ts
// The example answer is 3, 4, 5, but the correct answer is 2, 3, 4, 5, 1, 2 
const iter = dropUntil((a) => a < 3, [1, 2, 3, 4, 5, 1, 2])
```

## To-Be
I think it is a mistake copying and pasting `dropWhile`. Considering the context, I think it's the right way to change it as follows.
```ts
const iter = dropUntil((a) => a > 3, [1, 2, 3, 4, 5, 1, 2]);
```