### PR TITLE
refactor: 타입 가드 함수의 추론 결과 개선

### DIFF
--- a/src/Lazy/dropRight.ts
+++ b/src/Lazy/dropRight.ts
@@ -8,9 +8,7 @@ import concurrent, { isConcurrent } from "./concurrent";
 function* sync<T>(length: number, iterable: Iterable<T>) {
   const arr =
     isArray(iterable) || isString(iterable) ? iterable : toArray(iterable);
-  for (let i = 0; i < arr.length - length; i++) {
-    yield arr[i];
-  }
+  for (let i = 0; i < arr.length - length; i++) yield arr[i] as T;
 }
 
 async function* asyncSequential<T>(length: number, iterable: AsyncIterable<T>) {

--- a/src/Lazy/takeRight.ts
+++ b/src/Lazy/takeRight.ts
@@ -11,7 +11,8 @@ function* sync<A>(length: number, iterable: Iterable<A>): IterableIterator<A> {
     isArray(iterable) || isString(iterable) ? iterable : toArray(iterable);
   const index = arr.length - length;
   for (let i = index; i < arr.length; i++) {
-    if (arr[i]) yield arr[i];
+    isIterable(iterable);
+    if (arr[i]) yield arr[i] as A;
   }
 }
 
@@ -19,9 +20,7 @@ async function* asyncSequential<T>(length: number, iterable: AsyncIterable<T>) {
   const arr = await toArray(iterable);
   const index = arr.length - length;
   for (let i = index; i < arr.length; i++) {
-    if (arr[i]) {
-      yield arr[i];
-    }
+    if (arr[i]) yield arr[i];
   }
 }
 

--- a/src/isArray.ts
+++ b/src/isArray.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Returns true if `a` is an Array.
  *
@@ -9,7 +7,7 @@ import type Include from "./types/Include";
  * isArray(2); // false
  * ```
  */
-const isArray = <T>(a: T): a is Include<T, unknown[] | Readonly<unknown[]>> =>
-  Array.isArray(a);
+const isArray = (input: unknown): input is unknown[] | Readonly<unknown[]> =>
+  Array.isArray(input);
 
 export default isArray;

--- a/src/isBoolean.ts
+++ b/src/isBoolean.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Returns true if `n` is a Boolean.
  *
@@ -10,6 +8,6 @@ import type Include from "./types/Include";
  * isBoolean("FxTS"); // false
  * ```
  */
-const isBoolean = <T>(n: T): n is Include<T, boolean> => typeof n === "boolean";
-
+const isBoolean = (input: unknown): input is boolean =>
+  typeof input === "boolean";
 export default isBoolean;

--- a/src/isNil.ts
+++ b/src/isNil.ts
@@ -1,6 +1,5 @@
 import isNull from "./isNull";
 import isUndefined from "./isUndefined";
-import type Include from "./types/Include";
 
 /**
  * Checks if the given value is `null` or `undefined`.
@@ -13,7 +12,6 @@ import type Include from "./types/Include";
  * isNil(null); // true
  * ```
  */
-const isNil = <T>(a: T): a is Include<T, null | undefined> =>
-  isUndefined(a) || isNull(a);
-
+const isNil = (input: unknown): input is null | undefined =>
+  isUndefined(input) || isNull(input);
 export default isNil;

--- a/src/isNull.ts
+++ b/src/isNull.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Checks if the given value is `null`.
  *
@@ -11,6 +9,6 @@ import type Include from "./types/Include";
  * isNull(null); // true
  * ```
  */
-const isNull = <T>(input: T): input is Include<T, null> => input === null;
+const isNull = (input: unknown): input is null => input === null;
 
 export default isNull;

--- a/src/isNumber.ts
+++ b/src/isNumber.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Returns true if `n` is a Number.
  *
@@ -9,6 +7,5 @@ import type Include from "./types/Include";
  * isNumber("a"); // false
  * ```
  */
-const isNumber = <T>(n: T): n is Include<T, number> => typeof n === "number";
-
+const isNumber = (input: unknown): input is number => typeof input === "number";
 export default isNumber;

--- a/src/isObject.ts
+++ b/src/isObject.ts
@@ -1,4 +1,4 @@
-import type Include from "./types/Include";
+import isNull from "./isNull";
 
 /**
  * Checks if value is the type of object.
@@ -12,9 +12,9 @@ import type Include from "./types/Include";
  * isObject(123); // false
  * ```
  */
-const isObject = <T>(a: T): a is Include<T, object> => {
-  const type = typeof a;
-  return a != null && (type === "object" || type === "function");
+const isObject = (input: unknown): input is object => {
+  const type = typeof input;
+  return !isNull(input) && (type === "object" || type === "function");
 };
 
 export default isObject;

--- a/src/isString.ts
+++ b/src/isString.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Returns true if `s` is a String.
  *
@@ -9,6 +7,5 @@ import type Include from "./types/Include";
  * isString(2); // false
  * ```
  */
-const isString = <T>(s: T): s is Include<T, string> => typeof s === "string";
-
+const isString = (input: unknown): input is string => typeof input === "string";
 export default isString;

--- a/src/isUndefined.ts
+++ b/src/isUndefined.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Checks if the given value is `undefined`.
  *
@@ -9,6 +7,6 @@ import type Include from "./types/Include";
  * isUndefined(2); // false
  * ```
  */
-const isUndefined = <T>(a: T): a is Include<T, undefined> => a === undefined;
+const isUndefined = (input: unknown): input is undefined => input === undefined;
 
 export default isUndefined;

--- a/src/types/Include.ts
+++ b/src/types/Include.ts
@@ -1,3 +1,0 @@
-type Include<T, N> = T extends N ? T : never;
-
-export default Include;


### PR DESCRIPTION
Fixes #
과거에 비해 TS에서 제공하는 타입 가드의 타입 추론 능력이 향상되었습니다. 그에 비해 기존에 사용하던 Include 연산은 부정확한 연산 결과를 나타내는 경우가 있었습니다. (예를 들어, isString<unknown>은 never로 연산됩니다.)
따라서 타입 가드 함수들의 시그니처를 수정하여 더 정확한 타입 추론 결과를 나타내도록 수정했습니다.

TS는 현재 타입 가드 함수의 결과로 교집합(Intersect) 연산 결과를 표시합니다.

before
```ts
isString(input: any); // input is any;
isString(input: unknown); // input is never;
isString(input: number | "1" | "2"); // input is "1" | "2";
```

after
```ts
isString(input: any); // input is string;
isString(input: unknown); // input is string;
isString(input: number | "1" | "2"); // input is "1" | "2";
isString(input: number); // input is never;
```