### PR TITLE
refactor: typeguard 타입추론 개선

### DIFF
--- a/src/Lazy/dropRight.ts
+++ b/src/Lazy/dropRight.ts
@@ -9,7 +9,7 @@ function* sync<T>(length: number, iterable: Iterable<T>) {
   const arr =
     isArray(iterable) || isString(iterable) ? iterable : toArray(iterable);
   for (let i = 0; i < arr.length - length; i++) {
-    yield arr[i];
+    yield arr[i] as T;
   }
 }
 

--- a/src/Lazy/takeRight.ts
+++ b/src/Lazy/takeRight.ts
@@ -11,7 +11,7 @@ function* sync<A>(length: number, iterable: Iterable<A>): IterableIterator<A> {
     isArray(iterable) || isString(iterable) ? iterable : toArray(iterable);
   const index = arr.length - length;
   for (let i = index; i < arr.length; i++) {
-    if (arr[i]) yield arr[i];
+    if (arr[i]) yield arr[i] as A;
   }
 }
 

--- a/src/isArray.ts
+++ b/src/isArray.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Returns true if `a` is an Array.
  *
@@ -9,7 +7,7 @@ import type Include from "./types/Include";
  * isArray(2); // false
  * ```
  */
-const isArray = <T>(a: T): a is Include<T, unknown[] | Readonly<unknown[]>> =>
-  Array.isArray(a);
+const isArray = <T>(input: T): input is T & (unknown[] | Readonly<unknown[]>) =>
+  Array.isArray(input);
 
 export default isArray;

--- a/src/isBoolean.ts
+++ b/src/isBoolean.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Returns true if `n` is a Boolean.
  *
@@ -10,6 +8,7 @@ import type Include from "./types/Include";
  * isBoolean("FxTS"); // false
  * ```
  */
-const isBoolean = <T>(n: T): n is Include<T, boolean> => typeof n === "boolean";
+const isBoolean = <T>(input: T): input is T & boolean =>
+  typeof input === "boolean";
 
 export default isBoolean;

--- a/src/isNil.ts
+++ b/src/isNil.ts
@@ -1,6 +1,5 @@
 import isNull from "./isNull";
 import isUndefined from "./isUndefined";
-import type Include from "./types/Include";
 
 /**
  * Checks if the given value is `null` or `undefined`.
@@ -13,7 +12,7 @@ import type Include from "./types/Include";
  * isNil(null); // true
  * ```
  */
-const isNil = <T>(a: T): a is Include<T, null | undefined> =>
-  isUndefined(a) || isNull(a);
+const isNil = <T>(input: T): input is T & (null | undefined) =>
+  isUndefined(input) || isNull(input);
 
 export default isNil;

--- a/src/isNull.ts
+++ b/src/isNull.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Checks if the given value is `null`.
  *
@@ -11,6 +9,6 @@ import type Include from "./types/Include";
  * isNull(null); // true
  * ```
  */
-const isNull = <T>(input: T): input is Include<T, null> => input === null;
+const isNull = <T>(input: T): input is T & null => input === null;
 
 export default isNull;

--- a/src/isNumber.ts
+++ b/src/isNumber.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Returns true if `n` is a Number.
  *
@@ -9,6 +7,7 @@ import type Include from "./types/Include";
  * isNumber("a"); // false
  * ```
  */
-const isNumber = <T>(n: T): n is Include<T, number> => typeof n === "number";
+const isNumber = <T>(input: T): input is T & number =>
+  typeof input === "number";
 
 export default isNumber;

--- a/src/isObject.ts
+++ b/src/isObject.ts
@@ -1,4 +1,4 @@
-import type Include from "./types/Include";
+import isNil from "./isNil";
 
 /**
  * Checks if value is the type of object.
@@ -12,9 +12,9 @@ import type Include from "./types/Include";
  * isObject(123); // false
  * ```
  */
-const isObject = <T>(a: T): a is Include<T, object> => {
-  const type = typeof a;
-  return a != null && (type === "object" || type === "function");
+const isObject = <T>(input: T): input is T & object => {
+  const type = typeof input;
+  return !isNil(input) && (type === "object" || type === "function");
 };
 
 export default isObject;

--- a/src/isString.ts
+++ b/src/isString.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Returns true if `s` is a String.
  *
@@ -9,6 +7,7 @@ import type Include from "./types/Include";
  * isString(2); // false
  * ```
  */
-const isString = <T>(s: T): s is Include<T, string> => typeof s === "string";
+const isString = <T>(input: T): input is T & string =>
+  typeof input === "string";
 
 export default isString;

--- a/src/isUndefined.ts
+++ b/src/isUndefined.ts
@@ -1,5 +1,3 @@
-import type Include from "./types/Include";
-
 /**
  * Checks if the given value is `undefined`.
  *
@@ -9,6 +7,7 @@ import type Include from "./types/Include";
  * isUndefined(2); // false
  * ```
  */
-const isUndefined = <T>(a: T): a is Include<T, undefined> => a === undefined;
+const isUndefined = <T>(input: T): input is T & undefined =>
+  input === undefined;
 
 export default isUndefined;

--- a/src/types/FalsyTypeOf.ts
+++ b/src/types/FalsyTypeOf.ts
@@ -1,0 +1,5 @@
+import type Falsy from "./Falsy";
+
+type FalsyTypesOf<T> = T extends Falsy ? T : never;
+
+export default FalsyTypesOf;

--- a/src/types/Include.ts
+++ b/src/types/Include.ts
@@ -1,3 +1,0 @@
-type Include<T, N> = T extends N ? T : never;
-
-export default Include;

--- a/type-check/throwError.test.ts
+++ b/type-check/throwError.test.ts
@@ -11,7 +11,7 @@ const res2 = pipe(
 );
 
 const res3 = pipe(
-  0,
+  0 as const,
 
   unless(
     isNumber,
@@ -31,6 +31,6 @@ const res4 = pipe(
 checks([
   check<typeof res1, never, Test.Pass>(),
   check<typeof res2, never, Test.Pass>(),
-  check<typeof res3, number, Test.Pass>(),
-  check<typeof res4, number, Test.Pass>(),
+  check<typeof res3, 0, Test.Pass>(),
+  check<typeof res4, never, Test.Pass>(),
 ]);


### PR DESCRIPTION
Fixes #
기존 타입가드 함수의 타입 추론 결과의 정확도를 향상시켰습니다.
최신 TS 버전은 타입가드의 결과를 input 타입과 교집합으로 계삽합니다. 이를 참고하여 타입 연산식을 수정했습니다.

아쉽게도 여전히 input이 any인 경우는 잘못된 결과가 추론됩니다.

before
```ts
isString(input: any); // input is any;
isString(input: unknown); // input is never;
isString(input: number | "1" | "2"); // input is "1" | "2";
```

after
```ts
isString(input: any); // input is any;
isString(input: unknown); // input is string;
isString(input: number | "1" | "2"); // input is "1" | "2";
isString(input: number); // input is never;
```