### PR TITLE
fix: fix incorrect active color in navigation bar

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -57,8 +57,8 @@ const config = {
           src: "img/fxts.png",
         },
         items: [
-          { to: "/docs/getting-started", label: "Docs", position: "left" },
-          { to: "/docs", label: "API", position: "left" },
+          { to: "/docs/getting-started", label: "Docs", position: "left",type:'doc', docId:'getting-started' },
+          { to: "/docs", label: "API", position: "left", type:'doc', docId: 'index' },
           {
             href: "https://github.com/marpple/fxts",
             label: "GitHub",


### PR DESCRIPTION
Fix incorrect active color in navigation bar

Previously, the navigation items in both doc and API sections were highlighted simultaneously.
This PR separates the active states by.
- Using `docId` to determine which item should be highlighted

This ensures only the correct navigation item is highlighted at a time.

# Before

<img width="497" alt="스크린샷 2024-10-25 오후 1 51 53" src="https://github.com/user-attachments/assets/f796809a-e65b-4869-9514-235b4e9c27f1">

# After

<img width="565" alt="스크린샷 2024-10-25 오후 1 52 06" src="https://github.com/user-attachments/assets/798a1dc1-eaa7-40aa-a451-aac072e5bafb">

## In video

https://github.com/user-attachments/assets/25c682c3-0fec-4bdd-a8de-57b5fb1d0072



