### PR TITLE
fix: add filter to remove falsy values in generateExports

### DIFF
--- a/build/generateExports.ts
+++ b/build/generateExports.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from "fs/promises";
 import { glob } from "glob";
 
-import { drop, map, not, pipe, reduce } from "../src/index";
+import { drop, filter, identity, map, not, pipe, reduce } from "../src/index";
 
 const SOURCE_DIR = "./src";
 const OUTPUT_DIR = "./dist";
@@ -54,6 +54,7 @@ async function generateExports() {
 
   const subPathExports = pipe(
     fileNames,
+    filter(identity),
     map((name) => {
       const conditionalSubPaths = {
         types: `${TYPES_ROOT_DIR}/${name}.d.ts`,


### PR DESCRIPTION
Fixes #294 

as-is (package.json)
<img width="392" alt="image" src="https://github.com/user-attachments/assets/ac3809d8-e238-486b-bab5-ee24b24ff847">



to-be
<img width="381" alt="image" src="https://github.com/user-attachments/assets/da506ae3-9931-45c6-9770-1fdae63f555f">

