### PR TITLE
fix: change `fx.zip` evaluation arguments  order

### DIFF
--- a/src/Lazy/fx.ts
+++ b/src/Lazy/fx.ts
@@ -228,8 +228,13 @@ class FxAsyncIterable<A> {
    *
    * see {@link https://fxts.dev/docs/zip | zip}
    */
-  zip<B>(iterable: Iterable<B> | AsyncIterable<B>): FxAsyncIterable<[A, B]> {
-    return new FxAsyncIterable(zip(this.asyncIterable, iterable));
+  zip<B>(iterable: Iterable<B> | AsyncIterable<B>): FxAsyncIterable<[B, A]> {
+    return new FxAsyncIterable(
+      zip(
+        isAsyncIterable(iterable) ? iterable : toAsync(iterable),
+        this.asyncIterable,
+      ),
+    );
   }
 
   /**
@@ -562,8 +567,8 @@ export class FxIterable<A> {
    *
    * see {@link https://fxts.dev/docs/zip | zip}
    */
-  zip<B>(iterable: Iterable<B>): FxIterable<[A, B]> {
-    return new FxIterable(zip(this.iterable, iterable));
+  zip<B>(iterable: Iterable<B>): FxIterable<[B, A]> {
+    return new FxIterable(zip(iterable, this.iterable));
   }
 
   /**

--- a/test/Lazy/zip.spec.ts
+++ b/test/Lazy/zip.spec.ts
@@ -100,17 +100,17 @@ describe("zip", function () {
       const res1 = fx([1, 2, 3]).zip(["5", "6", "7", "8"]).toArray();
 
       expect(res1).toEqual([
-        [1, "5"],
-        [2, "6"],
-        [3, "7"],
+        ["5", 1],
+        ["6", 2],
+        ["7", 3],
       ]);
 
       const res2 = fx([1, 2, 3, 4]).zip(["5", "6", "7"]).toArray();
 
       expect(res2).toEqual([
-        [1, "5"],
-        [2, "6"],
-        [3, "7"],
+        ["5", 1],
+        ["6", 2],
+        ["7", 3],
       ]);
     });
   });
@@ -202,9 +202,9 @@ describe("zip", function () {
         .toArray();
 
       expect(res1).toEqual([
-        [1, "5"],
-        [2, "6"],
-        [3, "7"],
+        ["5", 1],
+        ["6", 2],
+        ["7", 3],
       ]);
 
       const res2 = await fx([1, 2, 3, 4])
@@ -213,9 +213,9 @@ describe("zip", function () {
         .toArray();
 
       expect(res2).toEqual([
-        [1, "5"],
-        [2, "6"],
-        [3, "7"],
+        ["5", 1],
+        ["6", 2],
+        ["7", 3],
       ]);
     });
 

--- a/type-check/Lazy/zip.test.ts
+++ b/type-check/Lazy/zip.test.ts
@@ -24,6 +24,6 @@ checks([
   check<typeof res4, IterableIterator<[string, number]>, Test.Pass>(),
   check<typeof res5, AsyncIterableIterator<[string, number]>, Test.Pass>(),
   check<typeof res6, AsyncIterableIterator<[string, number]>, Test.Pass>(),
-  check<typeof res7, [number, string][], Test.Pass>(),
-  check<typeof res8, Promise<[number, string][]>, Test.Pass>(),
+  check<typeof res7, [string, number][], Test.Pass>(),
+  check<typeof res8, Promise<[string, number][]>, Test.Pass>(),
 ]);


### PR DESCRIPTION
Fixes the order in which zip evaluates arguments is reversed.