### PR TITLE
fix: add filter overload to fx

### DIFF
--- a/src/Lazy/fx.ts
+++ b/src/Lazy/fx.ts
@@ -111,6 +111,8 @@ class FxAsyncIterable<A> {
    *
    * see {@link https://fxts.dev/docs/filter | filter}
    */
+  filter<B extends A>(f: (a: A) => a is B): FxAsyncIterable<B>;
+  filter(f: (a: A) => unknown): FxAsyncIterable<A>;
   filter(f: (a: A) => unknown): FxAsyncIterable<A> {
     return new FxAsyncIterable(filter(f, this.asyncIterable));
   }
@@ -452,6 +454,8 @@ export class FxIterable<A> {
    *
    * see {@link https://fxts.dev/docs/filter | filter}
    */
+  filter<B extends A>(f: (a: A) => a is B): FxIterable<B>;
+  filter(f: (a: A) => unknown): FxIterable<A>;
   filter(f: (a: A) => unknown): FxIterable<A> {
     return new FxIterable(filter(f, this.iterable));
   }

--- a/type-check/Lazy/fx.test.ts
+++ b/type-check/Lazy/fx.test.ts
@@ -24,6 +24,10 @@ const res7 = fx(toAsync([1, 2, 3]))
 const res8 = [...fx([1, 2, 3])];
 const res9 = [...fx("abc")];
 
+const res10 = fx([1, null, 2, null, 3])
+  .filter((n): n is number => n !== null)
+  .toArray();
+
 checks([
   check<typeof res1, Cast<Iterable<number>, typeof res1>, Test.Pass>(),
   check<typeof res2, number[], Test.Pass>(),
@@ -34,4 +38,5 @@ checks([
   check<typeof res7, Promise<number[]>, Test.Pass>(),
   check<typeof res8, number[], Test.Pass>(),
   check<typeof res9, string[], Test.Pass>(),
+  check<typeof res10, number[], Test.Pass>(),
 ]);


### PR DESCRIPTION
Fixes #

I encountered some inconvenience when using the filter method on the fx object.
It seems that when using a type guard function with filter, it doesn't affect the resulting type as expected.
To address this, I added an overload to the filter method on the fx object.
I’d appreciate it if you could take a look. 🙇‍♂️

before: 
<img width="383" alt="image" src="https://github.com/user-attachments/assets/8048e458-86c9-4987-bbfa-a7018db62a39" />

after:
<img width="383" alt="image" src="https://github.com/user-attachments/assets/0139915b-ecf2-40d7-a618-e5b6a4181b47" />
