### PR TITLE
fix: entries return type

### DIFF
--- a/src/Lazy/entries.ts
+++ b/src/Lazy/entries.ts
@@ -1,7 +1,14 @@
-type Entries<
-  T extends Record<string, any>,
-  K extends keyof T,
-> = K extends string ? [K, T[K]] : never;
+import type Key from "../types/Key";
+
+type NumberToString<T extends number> = `${T}` extends infer R extends string
+  ? R
+  : never;
+
+type Entries<T extends Record<Key, any>, K extends keyof T> = K extends number
+  ? [NumberToString<K>, T[K]]
+  : K extends Key
+  ? [K, T[K]]
+  : never;
 
 /**
  *
@@ -18,7 +25,7 @@ type Entries<
  * see {@link https://fxts.dev/docs/fromEntries | fromEntries}
  */
 
-function* entries<T extends Record<string, any>>(
+function* entries<T extends Record<Key, any>>(
   obj: T,
 ): Generator<Entries<T, keyof T>, void> {
   for (const k in obj) {

--- a/type-check/Lazy/entries.test.ts
+++ b/type-check/Lazy/entries.test.ts
@@ -22,6 +22,11 @@ type Obj = {
 const fn = (obj: Obj) => entries(obj);
 const res3 = fn({ hello: 3 });
 
+const obj2: {
+  [x: number]: string;
+} = { 2025: "year", 2024: "year" };
+const res4 = entries(obj2);
+
 checks([
   check<
     typeof res1,
@@ -51,4 +56,9 @@ checks([
   >(),
 
   check<typeof res3, Generator<[string, number], void, unknown>, Test.Pass>(),
+  check<
+    typeof res4,
+    Generator<[`${number}`, string], void, unknown>,
+    Test.Pass
+  >(),
 ]);


### PR DESCRIPTION
A situation where the type does not work based on the JavaScript runtime behavior.

Modified to transfer types based on the JavaScript runtime behavior.

Both string and number are entered as key values ​​in the object.
```
var obj = { 2025 : 'hello' }
obj[2025] // hello
obj['2025'] // hello
```

The results of `Object.keys(obj)`, `Object.entries`, and `for k in obj` are all strings, so if the first key of `entries` is a number, the type is transferred as string.

The existing response type is maintained(Maintaining backward compatibility)