### PR TITLE
fix: use Extract type for preventing type widening in isArray function

### DIFF
--- a/src/isArray.ts
+++ b/src/isArray.ts
@@ -7,7 +7,8 @@
  * isArray(2); // false
  * ```
  */
-const isArray = <T>(input: T): input is T & (unknown[] | Readonly<unknown[]>) =>
-  Array.isArray(input);
+const isArray = <T>(
+  input: T,
+): input is Extract<T, unknown[] | Readonly<unknown[]>> => Array.isArray(input);
 
 export default isArray;

--- a/type-check/isArray.test.ts
+++ b/type-check/isArray.test.ts
@@ -1,4 +1,4 @@
-import { isArray, negate, pipe, throwIf } from "../src";
+import { isArray, map, negate, pipe, prop, throwIf, when } from "../src";
 import * as Test from "../src/types/Test";
 
 const { checks, check } = Test;
@@ -18,9 +18,27 @@ const res4 = pipe(
   throwIf(negate(isArray)),
 );
 
+type Profile = {
+  thumbnail: string;
+  nickname?: string;
+  id: string;
+};
+
+type UserState = {
+  profiles: Profile[];
+};
+
+declare const state: UserState;
+
+const res5 = pipe(prop("profiles", state), throwIf(negate(isArray)));
+
 checks([
   check<typeof res1, boolean, Test.Pass>(),
   check<typeof res2, boolean, Test.Pass>(),
   check<typeof res3, readonly [1, 2, 3], Test.Pass>(),
   check<typeof res4, number[], Test.Pass>(),
+
+  // this type test prove #317 issue is resolved
+  // isArray type guard infer generic type `T` to `Profile[]` type instead of `unknown[]` type
+  check<typeof res5, Profile[], Test.Pass>(),
 ]);


### PR DESCRIPTION
Fixes #317 

**This changes that use `Extract` utility type instead of instersection type prevent unintented type widening.**
In the previous implemetation generic type `T` has been sometimes interpreted as `unknown[]` because of tendency to widen types.

**All tests were passed.**


