### PR TITLE
fix: Improve `when` function's type safety for type guard predicates

### DIFF
--- a/src/when.ts
+++ b/src/when.ts
@@ -43,7 +43,7 @@ import isUndefined from "./isUndefined";
 function when<T, S extends T, R>(
   predicate: (input: T) => input is S,
   callback: (input: S) => R,
-): (a: T) => Exclude<T, S>;
+): (a: T) => R | Exclude<T, S>;
 function when<T, R>(
   predicate: (input: T) => boolean,
   callback: (input: T) => R,
@@ -52,7 +52,7 @@ function when<T, S extends T, R>(
   predicate: (input: T) => input is S,
   callback: (input: S) => R,
   a: T,
-): Exclude<T, S>;
+): R | Exclude<T, S>;
 function when<T, R>(
   predicate: (input: T) => boolean,
   callback: (input: T) => R,

--- a/test/when.spec.ts
+++ b/test/when.spec.ts
@@ -1,37 +1,80 @@
 import { isString, pipe, when } from "../src";
 
 describe("when", function () {
-  const test = <T>(value: T) =>
-    when(
-      (value) => value === 100,
-      (value) => {
-        expect(value).toBeTruthy();
-      },
-      value,
-    );
-  const withPipe = <T>(value: T) =>
-    pipe(
-      value,
-      test,
-      when(isString, () => "Hello fxts"),
-    );
+  describe("with a general predicate", () => {
+    const test = <T>(value: T) =>
+      when(
+        (value) => value === 100,
+        (value) => {
+          expect(value).toBeTruthy();
+          return "value is 100";
+        },
+        value,
+      );
+    const withPipe = <T>(value: T) =>
+      pipe(
+        value,
+        test,
+        when(isString, () => "Hello fxts"),
+      );
 
-  it("If the input value is a number, it will be filtered out by the first 'when' function. And throw undefined.", () => {
-    const INPUT_VALUE = 100;
+    it("If the input value is a number 100, the callback is executed and returns its result.", () => {
+      const INPUT_VALUE = 100;
+      expect(test(INPUT_VALUE)).toBe("value is 100");
+    });
 
-    test(INPUT_VALUE);
-    withPipe(INPUT_VALUE);
+    it("If the input value does not match predicate, it returns the original value.", () => {
+      const INPUT_VALUE = "Hello World";
+      expect(test(INPUT_VALUE)).toBe("Hello World");
+    });
+
+    it("If nothing matches, all 'when' functions will be passed.", () => {
+      const INPUT_VALUE = [1, 2, 3, 4];
+      expect(test(INPUT_VALUE)).toEqual(INPUT_VALUE);
+      expect(withPipe(INPUT_VALUE)).toEqual(INPUT_VALUE);
+    });
   });
-  it("If the input value is a string, it will be filtered out by the second 'when' function. And return value is 'Hello fxts'", () => {
-    const INPUT_VALUE = "Hello World";
 
-    expect(test(INPUT_VALUE)).toBe("Hello World");
-    expect(withPipe(INPUT_VALUE)).toBe("Hello fxts");
-  });
-  it("If nothing matches, all 'when' functions will be passed.", () => {
-    const INPUT_VALUE = [1, 2, 3, 4];
+  describe("with a type guard predicate", () => {
+    type Shape =
+      | { type: "circle"; radius: number }
+      | { type: "square"; side: number };
 
-    expect(test(INPUT_VALUE)).toEqual(INPUT_VALUE);
-    expect(withPipe(INPUT_VALUE)).toEqual(INPUT_VALUE);
+    const isCircle = (
+      shape: Shape,
+    ): shape is { type: "circle"; radius: number } => shape.type === "circle";
+
+    it("should return the result of the callback when the type guard is true", () => {
+      const myShape: Shape = { type: "circle", radius: 10 };
+      const result = when(
+        isCircle,
+        (circle) => `A circle with radius ${circle.radius}`,
+        myShape,
+      );
+      expect(result).toBe("A circle with radius 10");
+    });
+
+    it("should return the original value when the type guard is false", () => {
+      const anotherShape: Shape = { type: "square", side: 5 };
+      const result = when(
+        isCircle,
+        (circle) => `A circle with radius ${circle.radius}`,
+        anotherShape,
+      );
+      expect(result).toEqual(anotherShape);
+    });
+
+    it("should work correctly with pipe", () => {
+      const myShape: Shape = { type: "circle", radius: 10 };
+      const anotherShape: Shape = { type: "square", side: 5 };
+
+      const shapeHandler = when(
+        isCircle,
+        (circle) => `A circle with radius ${circle.radius}`,
+      );
+
+      expect(pipe(myShape, shapeHandler)).toBe("A circle with radius 10");
+      expect(pipe(anotherShape, shapeHandler)).toEqual(anotherShape);
+    });
   });
 });

--- a/type-check/when.test.ts
+++ b/type-check/when.test.ts
@@ -22,7 +22,7 @@ const check4 = when(
 checks([
   check<typeof VALUE_1, 100, Test.Pass>(),
   check<typeof check1, string, Test.Pass>(),
-  check<typeof check2, number, Test.Pass>(),
+  check<typeof check2, string | number, Test.Pass>(),
   check<typeof check3, typeof VALUE_2 | string, Test.Pass>(),
   check<typeof check4, typeof VALUE_2 | string, Test.Pass>(),
 ]);

--- a/type-check/when.test.ts
+++ b/type-check/when.test.ts
@@ -19,10 +19,48 @@ const check4 = when(
   VALUE_2,
 );
 
+// New test cases for R | Exclude<T, S>
+type Shape =
+  | { type: "circle"; radius: number }
+  | { type: "square"; side: number };
+const myShape: Shape = { type: "circle", radius: 10 };
+const anotherShape: Shape = { type: "square", side: 5 };
+
+const isCircle = (
+  shape: Shape,
+): shape is { type: "circle"; radius: number } => {
+  return shape.type === "circle";
+};
+
+// When predicate is a type guard and is true at runtime
+const check5 = when(
+  isCircle,
+  (circle) => `A circle with radius ${circle.radius}`, // R = string
+  myShape,
+);
+
+// When predicate is a type guard and is false at runtime
+const check6 = when(
+  isCircle,
+  (circle) => `A circle with radius ${circle.radius}`, // R = string
+  anotherShape,
+);
+
+// Curried version
+const curriedWhen = when(
+  isCircle,
+  (circle) => `A circle with radius ${circle.radius}`,
+);
+const check7 = curriedWhen(myShape);
+
 checks([
   check<typeof VALUE_1, 100, Test.Pass>(),
   check<typeof check1, string, Test.Pass>(),
   check<typeof check2, string | number, Test.Pass>(),
   check<typeof check3, typeof VALUE_2 | string, Test.Pass>(),
   check<typeof check4, typeof VALUE_2 | string, Test.Pass>(),
+  // --- Added Tests ---
+  check<typeof check5, string, Test.Pass>(),
+  check<typeof check6, string | { type: "square"; side: number }, Test.Pass>(),
+  check<typeof check7, string | { type: "square"; side: number }, Test.Pass>(),
 ]);


### PR DESCRIPTION
**This PR enhances the `when` utility by correcting its return type signature** when used with a type guard predicate, significantly improving its type safety and predictability.

## The Problem
**This issue stems from a fundamental aspect of TypeScript's design: type checking occurs at compile-time without executing the code.** The type system cannot predict the runtime outcome of the predicate function (whether it will return `true` or `false`). **Therefore, a function's type signature must correctly account for all possible return paths.**
The previous signature for when with a type guard `((input: T) => input is S)` incorrectly returned `Exclude<T, S>`. This signature only described the outcome for a `false` predicate, creating a serious mismatch when the predicate was `true` at runtime.
For example, with the old signature:
```ts
type Shape = { type: "circle"; r: number } | { type: "square"; s: number };
const myShape: Shape = { type: "circle", r: 10 };

const result = when(
  (s): s is { type: "circle"; r: number } => s.type === "circle",
  (circle) => `Area: ${Math.PI * circle.r ** 2}`, // Returns a string (R)
  myShape
);

// At runtime, `result` is the string "Area: 314.15..."
// BUT, at compile-time, TypeScript would incorrectly infer the type of `result` as { type: "square", s: number }.
// This would lead to compile errors on valid operations (e.g. `result.toUpperCase()`)
// and allow invalid operations that would fail at runtime (e.g. `result.s`).
```

## The Solution
**The function's overloads have been updated to return `R | Exclude<T, S>`. This signature correctly represents all possible outcomes**:
`R`: The result of the callback function if the predicate is `true`.
`Exclude<T, S>`: The original value with its type narrowed to exclude `S` if the predicate is `false`.
This change makes the function's type signature "honest," **aligning the static type with the actual runtime behavior**.

## Testing
To support this change:
Type-check tests (`type-check/when.test.ts`) have been added to verify that the compiler correctly infers the new, more accurate `R | Exclude<T, S>` union type.
Runtime tests (`test/when.spec.ts`) have been added to confirm that the function behaves as expected with type guards, returning the correct value in both `true` and `false` scenarios.