### PR TITLE
Refactor groupBy import variables

### DIFF
--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -5,7 +5,6 @@ import type Cast from "./types/Cast";
 import type Equals from "./types/Equals";
 import type { GetKeyOf } from "./types/GetKeyOf";
 import type IterableInfer from "./types/IterableInfer";
-import type iterableInfer from "./types/IterableInfer";
 import type Key from "./types/Key";
 import type ReturnValueType from "./types/ReturnValueType";
 
@@ -135,7 +134,7 @@ function groupBy<
     );
   }
 
-  if (isAsyncIterable<iterableInfer<A>>(iterable)) {
+  if (isAsyncIterable<IterableInfer<A>>(iterable)) {
     return reduce(
       async (group, a) => {
         const key = await f(a);

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -1,9 +1,7 @@
 import { AsyncFunctionException } from "./_internal/error";
 import { isAsyncIterable, isIterable, isPromise } from "./_internal/utils";
 import reduce from "./reduce";
-import type Cast from "./types/Cast";
 import type Equals from "./types/Equals";
-import type { GetKeyOf } from "./types/GetKeyOf";
 import type IterableInfer from "./types/IterableInfer";
 import type Key from "./types/Key";
 import type ReturnValueType from "./types/ReturnValueType";


### PR DESCRIPTION
I will clean up the import statements in groupBy, removing any duplicate imports and also eliminating variables that are imported but no