### PR TITLE
feat: add `match` and `cases` (#346)

### DIFF
--- a/src/cases.ts
+++ b/src/cases.ts
@@ -1,0 +1,231 @@
+import { chunk } from "./Lazy";
+
+type Predicate<T> = (value: T) => boolean;
+type Refinement<T, T1 extends T> = (value: T) => value is T1;
+type Mapper<T, R> = (value: T) => R;
+type MapperByRefinement<Pred, R> = Pred extends (value: infer T) => boolean
+  ? Pred extends Refinement<T, infer T1>
+    ? Mapper<T1, R>
+    : Mapper<T, R>
+  : never;
+type Thrower<T> = (error: T) => never;
+type DefaultFn<T, R> = Mapper<T, R> | Thrower<T>;
+type EvenArray = unknown[] & { length: 0 | 2 | 4 | 6 | 8 | 10 | 12 };
+
+function cases(): (value: unknown) => typeof value;
+function cases<T, R>(defaultFn: DefaultFn<T, R>): (value: T) => R;
+function cases<T, P1 extends Predicate<T> | Refinement<T, T>, R>(
+  pred1: P1,
+  mapper1: MapperByRefinement<typeof pred1, R>,
+): (value: T) => T | R;
+function cases<T, P1 extends Predicate<T> | Refinement<T, T>, R>(
+  pred1: P1,
+  mapper1: MapperByRefinement<typeof pred1, R>,
+  defaultFn: DefaultFn<T, R>,
+): (value: T) => R;
+function cases<
+  T,
+  P1 extends Predicate<T> | Refinement<T, T>,
+  P2 extends Predicate<T> | Refinement<T, T>,
+  R,
+>(
+  pred1: P1,
+  mapper1: MapperByRefinement<typeof pred1, R>,
+  pred2: P2,
+  mapper2: MapperByRefinement<typeof pred2, R>,
+): (value: T) => T | R;
+function cases<
+  T,
+  P1 extends Predicate<T> | Refinement<T, T>,
+  P2 extends Predicate<T> | Refinement<T, T>,
+  R,
+>(
+  pred1: P1,
+  mapper1: MapperByRefinement<typeof pred1, R>,
+  pred2: P2,
+  mapper2: MapperByRefinement<typeof pred2, R>,
+  defaultFn: DefaultFn<T, R>,
+): (value: T) => R;
+function cases<
+  T,
+  P1 extends Predicate<T> | Refinement<T, T>,
+  P2 extends Predicate<T> | Refinement<T, T>,
+  P3 extends Predicate<T> | Refinement<T, T>,
+  R,
+>(
+  pred1: P1,
+  mapper1: MapperByRefinement<typeof pred1, R>,
+  pred2: P2,
+  mapper2: MapperByRefinement<typeof pred2, R>,
+  pred3: P3,
+  mapper3: MapperByRefinement<typeof pred3, R>,
+): (value: T) => T | R;
+function cases<
+  T,
+  P1 extends Predicate<T> | Refinement<T, T>,
+  P2 extends Predicate<T> | Refinement<T, T>,
+  P3 extends Predicate<T> | Refinement<T, T>,
+  R,
+>(
+  pred1: P1,
+  mapper1: MapperByRefinement<typeof pred1, R>,
+  pred2: P2,
+  mapper2: MapperByRefinement<typeof pred2, R>,
+  pred3: P3,
+  mapper3: MapperByRefinement<typeof pred3, R>,
+  defaultFn: DefaultFn<T, R>,
+): (value: T) => R;
+function cases<
+  T,
+  P1 extends Predicate<T> | Refinement<T, T>,
+  P2 extends Predicate<T> | Refinement<T, T>,
+  P3 extends Predicate<T> | Refinement<T, T>,
+  P4 extends Predicate<T> | Refinement<T, T>,
+  R,
+>(
+  pred1: P1,
+  mapper1: MapperByRefinement<typeof pred1, R>,
+  pred2: P2,
+  mapper2: MapperByRefinement<typeof pred2, R>,
+  pred3: P3,
+  mapper3: MapperByRefinement<typeof pred3, R>,
+  pred4: P4,
+  mapper4: MapperByRefinement<typeof pred4, R>,
+): (value: T) => T | R;
+function cases<
+  T,
+  P1 extends Predicate<T> | Refinement<T, T>,
+  P2 extends Predicate<T> | Refinement<T, T>,
+  P3 extends Predicate<T> | Refinement<T, T>,
+  P4 extends Predicate<T> | Refinement<T, T>,
+  R,
+>(
+  pred1: P1,
+  mapper1: MapperByRefinement<typeof pred1, R>,
+  pred2: P2,
+  mapper2: MapperByRefinement<typeof pred2, R>,
+  pred3: P3,
+  mapper3: MapperByRefinement<typeof pred3, R>,
+  pred4: P4,
+  mapper4: MapperByRefinement<typeof pred4, R>,
+  defaultFn: DefaultFn<T, R>,
+): (value: T) => R;
+function cases<
+  T,
+  P1 extends Predicate<T> | Refinement<T, T>,
+  P2 extends Predicate<T> | Refinement<T, T>,
+  P3 extends Predicate<T> | Refinement<T, T>,
+  P4 extends Predicate<T> | Refinement<T, T>,
+  P5 extends Predicate<T> | Refinement<T, T>,
+  R,
+>(
+  pred1: P1,
+  mapper1: MapperByRefinement<typeof pred1, R>,
+  pred2: P2,
+  mapper2: MapperByRefinement<typeof pred2, R>,
+  pred3: P3,
+  mapper3: MapperByRefinement<typeof pred3, R>,
+  pred4: P4,
+  mapper4: MapperByRefinement<typeof pred4, R>,
+  pred5: P5,
+  mapper5: MapperByRefinement<typeof pred5, R>,
+): (value: T) => T | R;
+function cases<
+  T,
+  P1 extends Predicate<T> | Refinement<T, T>,
+  P2 extends Predicate<T> | Refinement<T, T>,
+  P3 extends Predicate<T> | Refinement<T, T>,
+  P4 extends Predicate<T> | Refinement<T, T>,
+  P5 extends Predicate<T> | Refinement<T, T>,
+  R,
+>(
+  pred1: P1,
+  mapper1: MapperByRefinement<typeof pred1, R>,
+  pred2: P2,
+  mapper2: MapperByRefinement<typeof pred2, R>,
+  pred3: P3,
+  mapper3: MapperByRefinement<typeof pred3, R>,
+  pred4: P4,
+  mapper4: MapperByRefinement<typeof pred4, R>,
+  pred5: P5,
+  mapper5: MapperByRefinement<typeof pred5, R>,
+  defaultFn: DefaultFn<T, R>,
+): (value: T) => R;
+/**
+ * Returns a mapped value based on the first matching predicate.
+ * It's similar to `match`, but `cases` is more flexible.
+ * The predicates can return boolean or be type refinements.
+ *
+ * ```ts
+ * pipe(
+ *   [10, 20, 30],
+ *   map(cases(
+ *     lt(15), (n) => n + 20,
+ *     lt(25), (n) => n + 10,
+ *   )),
+ *   toArray,
+ * ) // [30, 30, 30]
+ * ```
+ *
+ * If the predicate is a type refinement, the corresponding mapper will receive the narrowed type.
+ * Else, the mapper will receive the original type.
+ * If there's no match, the input value is returned as is. (if the number of functions is even)
+ * Or the `default` function (the last function without paired predicate) is executed if provided.
+ * (if the number of functions is odd)
+ *
+ * ```ts
+ * type A = { a: string; }
+ * type B = A & { b: string; }
+ *
+ * pipe(
+ *   [{ a: "A", b: "B" }, { a: "A" }] as A[],
+ *   map(cases(
+ *    (n): n is B => "b" in n, (n) => n.b,
+ *    (n) => n.a,
+ *   )),
+ *  toArray,
+ * ) // ["B", "A"]
+ * ```
+ *
+ * As above mentioned, it's flexible than `match`.
+ * But the type inference is not as good as `match`.
+ * ```ts
+ * type A = { a: string; }
+ * type B = { b: string; }
+ *
+ * pipe(
+ *   [{ a: "A", b: "B" }, { a: "A" }, { b: "B" }] as (A | B)[],
+ *   peek(cases(
+ *     (n): n is A => "a" in n,
+ *     (n) => n.a,
+ *     (n) => n.b, // It's not properly narrowed, so `n` is `A | B`
+ *   )),
+ *   peek(match(  // But in `match`, the type is properly narrowed
+ *      (n): n is A => "a" in n,
+ *      (n) => n.a,
+ *      (n) => n.b, // It's properly narrowed, so `n` is `B`
+ *   )),
+ * )
+ * ```
+ *
+ * see {@link https://fxts.dev/docs/match | match}
+ */
+function cases<T, R>(...fns: ((x: T) => boolean | R)[]) {
+  return function (
+    value: T,
+  ): typeof fns extends EvenArray ? R | typeof value : R {
+    for (const pair of chunk(2, fns) as Generator<
+      [Predicate<T>, Mapper<T, R>] | [DefaultFn<T, R>, undefined]
+    >) {
+      if (!pair[1]) {
+        return pair[0](value);
+      }
+      if (pair[0](value)) {
+        return pair[1](value);
+      }
+    }
+    return value as typeof fns extends EvenArray ? typeof value : never;
+  };
+}
+
+export default cases;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import juxt from "./juxt";
 import last from "./last";
 import lt from "./lt";
 import lte from "./lte";
+import match from "./match";
 import max from "./max";
 import memoize from "./memoize";
 import min from "./min";
@@ -109,6 +110,7 @@ export {
   last,
   lt,
   lte,
+  match,
   max,
   memoize,
   min,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import add from "./add";
 import always from "./always";
 import apply from "./apply";
 import average from "./average";
+import cases from "./cases";
 import compactObject from "./compactObject";
 import consume from "./consume";
 import countBy from "./countBy";
@@ -74,6 +75,7 @@ export {
   apply,
   average,
   average as mean,
+  cases,
   compactObject,
   consume,
   countBy,

--- a/src/match.ts
+++ b/src/match.ts
@@ -85,6 +85,8 @@ type MatchPair<U, T extends U, R> = [Predicate<U, T>, Mapper<T, R>];
  *   toArray,
  * );
  * ```
+ *
+ * See {@link https://fxts.dev/docs/cases | cases}
  */
 function match(): (value: unknown) => never;
 function match<U, R>(...fns: [DefaultFn<U, never, R>]): (value: U) => R;

--- a/src/match.ts
+++ b/src/match.ts
@@ -1,0 +1,250 @@
+import { chunk } from "./Lazy";
+
+type Arrow = (...args: any[]) => any;
+type Predicate<U, T extends U> = (value: U) => value is T;
+type Mapper<T, R> = (value: T) => R;
+type Thrower<U> = (error: U) => never;
+type DefaultFn<U, T, R> = Mapper<Exclude<U, T>, R> | Thrower<Exclude<U, T>>;
+type MatchPair<U, T extends U, R> = [Predicate<U, T>, Mapper<T, R>];
+
+/**
+ * Returns a mapped value based on the first matching predicate.
+ * If a match is found, the corresponding mapper function is executed and its result is returned.
+ * If an odd number of functions are provided, the last function acts as a `default` function.
+ * The `default` function can either map the result value or throw an error.
+ * Among the other functions, odd-positioned functions are `predicate`s and even-positioned functions are `mapper`s.
+ * `predicate` and `mapper` functions form pairs with each other.
+ * A `predicate` returns a boolean value.
+ * A `mapper` transforms the input value to the result value.
+ * The input value is mapped to the result value by the `mapper` that pairs with the first `predicate` that returns true.
+ *
+ * @example
+ * ```ts
+ * pipe(
+ *   ['hello', 42, true],
+ *   map(
+ *     match(
+ *       isString, (s) => `String: ${s}`,
+ *       isNumber, (n) => `Number: ${n}`,
+ *       () => 'Unknown type'
+ *     )
+ *   ),
+ *   toArray,
+ * ); // ['String: hello', 'Number: 42', 'Unknown type']
+ *
+ * pipe(
+ *   ['hello', 42, true],
+ *   map(
+ *     match(
+ *       isString, (s) => `String: ${s}`,
+ *       isNumber, (n) => `Number: ${n}`,
+ *       throwError((input) => Error(`Unknown type: ${input}`))
+ *     )
+ *   ),
+ *   toArray,
+ * ); // Uncaught Error: Unknown type: true
+ * ```
+ *
+ * The max number of pairs is 5.
+ * So, if you want to match more than 5 types, you can use `match` inside a `default` function.
+ *
+ * @example
+ * ```ts
+ * interface A {
+ *   id: number;
+ *   type: "A";
+ * }
+ *
+ * const _as: A[] = [
+ *   { id: 1, type: "A" },
+ *   { id: 2, type: "A" },
+ *   { id: 3, type: "A" },
+ *   { id: 4, type: "A" },
+ *   { id: 5, type: "A" },
+ *   { id: 6, type: "A" },
+ * ] as const;
+ *
+ * const narrowA = <T extends number>(id: T) => (a: A): a is A & { id: T } =>
+ *   a.id === id;
+ *
+ * const getId = <T extends number>(a: A): T => a.id as T;
+ *
+ * const res4: (1 | 2 | 3 | 4 | 5 | 6)[] = pipe(
+ *   _as,
+ *   map(match(
+ *     narrowA(1), getId<1>,
+ *     narrowA(2), getId<2>,
+ *     narrowA(3), getId<3>,
+ *     narrowA(4), getId<4>,
+ *     narrowA(5), getId<5>,
+ *     match(
+ *       narrowA(6), getId<6>,
+ *       throwError((a) => Error(`Unknown id: ${a.id}`)),
+ *     ),
+ *   )),
+ *   toArray,
+ * );
+ * ```
+ */
+function match(): (value: unknown) => never;
+function match<U, R>(...fns: [DefaultFn<U, never, R>]): (value: U) => R;
+function match<U, R, T1 extends U>(
+  ...fns: U extends T1 ? [Predicate<U, T1>, Mapper<T1, R>] : never
+): (value: U) => R;
+function match<U, R, T1 extends U>(
+  ...fns: [Predicate<U, T1>, Mapper<T1, R>, DefaultFn<U, T1, R>]
+): (value: U) => R;
+function match<U, R, T1 extends U, T2 extends Exclude<U, T1>>(
+  ...fns: U extends T1 | T2
+    ? [Predicate<U, T1>, Mapper<T1, R>, Predicate<U, T2>, Mapper<T2, R>]
+    : never
+): (value: U) => R;
+function match<U, R, T1 extends U, T2 extends Exclude<U, T1>>(
+  ...fns: [
+    Predicate<U, T1>,
+    Mapper<T1, R>,
+    Predicate<U, T2>,
+    Mapper<T2, R>,
+    DefaultFn<U, T1 | T2, R>,
+  ]
+): (value: U) => R;
+function match<
+  U,
+  R,
+  T1 extends U,
+  T2 extends Exclude<U, T1>,
+  T3 extends Exclude<U, T1 | T2>,
+>(
+  ...fns: U extends T1 | T2 | T3
+    ? [
+        Predicate<U, T1>,
+        Mapper<T1, R>,
+        Predicate<U, T2>,
+        Mapper<T2, R>,
+        Predicate<U, T3>,
+        Mapper<T3, R>,
+      ]
+    : never
+): (value: U) => R;
+function match<
+  U,
+  R,
+  T1 extends U,
+  T2 extends Exclude<U, T1>,
+  T3 extends Exclude<U, T1 | T2>,
+>(
+  ...fns: [
+    Predicate<U, T1>,
+    Mapper<T1, R>,
+    Predicate<U, T2>,
+    Mapper<T2, R>,
+    Predicate<U, T3>,
+    Mapper<T3, R>,
+    DefaultFn<U, T1 | T2 | T3, R>,
+  ]
+): (value: U) => R;
+function match<
+  U,
+  R,
+  T1 extends U,
+  T2 extends Exclude<U, T1>,
+  T3 extends Exclude<U, T1 | T2>,
+  T4 extends Exclude<U, T1 | T2 | T3>,
+>(
+  ...fns: U extends T1 | T2 | T3 | T4
+    ? [
+        Predicate<U, T1>,
+        Mapper<T1, R>,
+        Predicate<U, T2>,
+        Mapper<T2, R>,
+        Predicate<U, T3>,
+        Mapper<T3, R>,
+        Predicate<U, T4>,
+        Mapper<T4, R>,
+      ]
+    : never
+): (value: U) => R;
+function match<
+  U,
+  R,
+  T1 extends U,
+  T2 extends Exclude<U, T1>,
+  T3 extends Exclude<U, T1 | T2>,
+  T4 extends Exclude<U, T1 | T2 | T3>,
+>(
+  ...fns: [
+    Predicate<U, T1>,
+    Mapper<T1, R>,
+    Predicate<U, T2>,
+    Mapper<T2, R>,
+    Predicate<U, T3>,
+    Mapper<T3, R>,
+    Predicate<U, T4>,
+    Mapper<T4, R>,
+    DefaultFn<U, T1 | T2 | T3 | T4, R>,
+  ]
+): (value: U) => R;
+function match<
+  U,
+  R,
+  T1 extends U,
+  T2 extends Exclude<U, T1>,
+  T3 extends Exclude<U, T1 | T2>,
+  T4 extends Exclude<U, T1 | T2 | T3>,
+  T5 extends Exclude<U, T1 | T2 | T3 | T4>,
+>(
+  ...fns: U extends T1 | T2 | T3 | T4 | T5
+    ? [
+        Predicate<U, T1>,
+        Mapper<T1, R>,
+        Predicate<U, T2>,
+        Mapper<T2, R>,
+        Predicate<U, T3>,
+        Mapper<T3, R>,
+        Predicate<U, T4>,
+        Mapper<T4, R>,
+        Predicate<U, T5>,
+        Mapper<T5, R>,
+      ]
+    : never
+): (value: U) => R;
+function match<
+  U,
+  R,
+  T1 extends U,
+  T2 extends Exclude<U, T1>,
+  T3 extends Exclude<U, T1 | T2>,
+  T4 extends Exclude<U, T1 | T2 | T3>,
+  T5 extends Exclude<U, T1 | T2 | T3 | T4>,
+>(
+  ...fns: [
+    Predicate<U, T1>,
+    Mapper<T1, R>,
+    Predicate<U, T2>,
+    Mapper<T2, R>,
+    Predicate<U, T3>,
+    Mapper<T3, R>,
+    Predicate<U, T4>,
+    Mapper<T4, R>,
+    Predicate<U, T5>,
+    Mapper<T5, R>,
+    DefaultFn<U, T1 | T2 | T3 | T4 | T5, R>,
+  ]
+): (value: U) => R;
+function match<U, R>(...fns: Arrow[]): (value: U) => R {
+  return function (value: U): R {
+    for (const pair of chunk(2, fns) as Generator<
+      MatchPair<U, U, R> | [Mapper<U, R> | Thrower<U>, undefined]
+    >) {
+      if (!pair[1]) {
+        return pair[0](value);
+      }
+      if (pair[0](value)) {
+        return pair[1](value);
+      }
+    }
+    throw new Error(`No match found for value: ${value}`);
+  };
+}
+
+export default match;

--- a/type-check/cases.test.ts
+++ b/type-check/cases.test.ts
@@ -1,0 +1,57 @@
+import { cases, lt, map, pipe, throwError, toArray } from "../src";
+import * as Test from "../src/types/Test";
+
+const { checks, check } = Test;
+
+const res1 = pipe(
+  [10, 20, 30],
+  map(
+    cases(
+      lt(15),
+      (n) => `less than 15: ${n}`,
+      lt(25),
+      (n) => `less than 25: ${n}`,
+      (n) => `greater than or equal to 25: ${n}`,
+    ),
+  ),
+  toArray,
+);
+
+const res2 = pipe(
+  [
+    { type: "A", a: "asd" },
+    { type: "B", b: true },
+    { type: "C", c: 123 },
+  ],
+  map(
+    cases(
+      (a): a is { type: "A"; a: string } => a.type === "A",
+      (n) => `Type A: ${n.a}`,
+      (a) => a.type === "B",
+      (n) => `Type B: ${n.b}`,
+      throwError((input) => Error(`Unknown type: ${JSON.stringify(input)}`)),
+    ),
+  ),
+  toArray,
+);
+
+type A = { a: string };
+type B = A & { b: string };
+
+const res3 = pipe(
+  [{ a: "A", b: "B" }, { a: "A" }] as A[],
+  map(
+    cases(
+      (n): n is B => "b" in n,
+      (n) => n.b,
+      (n) => n.a,
+    ),
+  ),
+  toArray,
+);
+
+checks([
+  check<typeof res1, string[], Test.Pass>(),
+  check<typeof res2, string[], Test.Pass>(),
+  check<typeof res3, string[], Test.Pass>(),
+]);

--- a/type-check/match.test.ts
+++ b/type-check/match.test.ts
@@ -1,0 +1,105 @@
+import {
+  isNumber,
+  isString,
+  map,
+  match,
+  pipe,
+  throwError,
+  toArray,
+} from "../src";
+import * as Test from "../src/types/Test";
+
+const { checks, check } = Test;
+
+const res1 = pipe(
+  ["hello", 42, true],
+  map(
+    match(
+      isString,
+      (s) => `String: ${s}`,
+      isNumber,
+      (n) => `Number: ${n}`,
+      () => "Unknown type",
+    ),
+  ),
+  toArray,
+);
+
+const res2 = pipe(
+  ["hello", 42, true],
+  map(
+    match(
+      isString,
+      (s) => `String: ${s}`,
+      isNumber,
+      (n) => `Number: ${n}`,
+      throwError((input) => Error(`Unknown type: ${input}`)),
+    ),
+  ),
+  toArray,
+);
+
+const res3 = pipe(
+  ["hello", 42],
+  map(
+    match<string | number, string | number, string, number>(
+      isString,
+      (s) => `String: ${s}`,
+      isNumber,
+      (n) => `Number: ${n}`,
+    ),
+  ),
+  toArray,
+);
+
+interface A {
+  id: number;
+  type: "A";
+}
+
+const _as: A[] = [
+  { id: 1, type: "A" },
+  { id: 2, type: "A" },
+  { id: 3, type: "A" },
+  { id: 4, type: "A" },
+  { id: 5, type: "A" },
+  { id: 6, type: "A" },
+] as const;
+
+const narrowA =
+  <T extends number>(id: T) =>
+  (a: A): a is A & { id: T } =>
+    a.id === id;
+
+const getId = <T extends number>(a: A): T => a.id as T;
+
+const res4 = pipe(
+  _as,
+  map(
+    match(
+      narrowA(1),
+      getId<1>,
+      narrowA(2),
+      getId<2>,
+      narrowA(3),
+      getId<3>,
+      narrowA(4),
+      getId<4>,
+      narrowA(5),
+      getId<5>,
+      match(
+        narrowA(6),
+        getId<6>,
+        throwError((a) => Error(`Unknown id: ${a.id}`)),
+      ),
+    ),
+  ),
+  toArray,
+);
+
+checks([
+  check<typeof res1, string[], Test.Pass>(),
+  check<typeof res2, string[], Test.Pass>(),
+  check<typeof res3, (string | number)[], Test.Pass>(),
+  check<typeof res4, (1 | 2 | 3 | 4 | 5 | 6)[], Test.Pass>(),
+]);


### PR DESCRIPTION
Fixes #346

I also implement [`cases`](https://github.com/marpple/FxTS/issues/346#issuecomment-3289138628), more flexible than match.
If you don't think `cases` is needed, I'll reqeust again without `cases`.
