### PR TITLE
feat: add noUncheckedIndexedAccess, exactOptionalPropertyTypes tsconfig options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
   }
 }


### PR DESCRIPTION
## Summary
This PR updates the TypeScript configuration to enable stricter type-checking rules. Specifically, it adds noUncheckedIndexedAccess and exactOptionalPropertyTypes to improve code reliability and type safety.

## Changes
Enable [noUncheckedIndexedAccess](typescriptlang.org/tsconfig/noUncheckedIndexedAccess.html): This ensures that accessing an index signature (like arrays or objects) includes undefined in the return type. This forces developers to check for existence before using the value, preventing potential runtime errors.

Enable [exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes): This enforces stricter handling of optional properties. It ensures that if a property is optional, it cannot be explicitly set to undefined unless undefined is also part of its type definition.

## Motivation
Enabling these options helps catch potential bugs earlier during development by enforcing stricter checks on indexed access and optional properties. This aligns with modern TypeScript best practices for writing robust and type-safe code.