### PR TITLE
fix: support map and set data structure

### DIFF
--- a/src/Lazy/entries.ts
+++ b/src/Lazy/entries.ts
@@ -4,33 +4,65 @@ type NumberToString<T extends number> = `${T}` extends infer R extends string
   ? R
   : never;
 
-type Entries<T extends Record<Key, any>, K extends keyof T> = K extends number
+type ObjectEntries<
+  T extends Record<Key, any>,
+  K extends keyof T,
+> = K extends number
   ? [NumberToString<K>, T[K]]
   : K extends string
   ? [K, T[K]]
   : never;
 
+type EntriesResult<T> = T extends Map<infer K, infer V>
+  ? Generator<[K, V], void>
+  : T extends Set<infer V>
+  ? Generator<[V, V], void>
+  : T extends Record<Key, any>
+  ? Generator<ObjectEntries<T, keyof T>, void>
+  : never;
+
 /**
  *
- * Returns an iterator of the own enumerable string keyed-value pairs.
+ * Returns an iterator of key-value pairs.
+ *
+ * Supports plain objects, Map, and Set:
+ * - For objects: returns own enumerable string keyed-value pairs
+ * - For Map: returns [key, value] pairs
+ * - For Set: returns [value, value] pairs
  *
  * @example
  * ```ts
- *
  * [...entries({ a: 1, b: "2", c: true })]
  * // [["a", 1], ["b", "2"], ["c", true]]
- * ```
  *
+ * [...entries(new Map([["a", 1], ["b", 2]]))]
+ * // [["a", 1], ["b", 2]]
+ *
+ * [...entries(new Set([1, 2, 3]))]
+ * // [[1, 1], [2, 2], [3, 3]]
+ * ```
  *
  * see {@link https://fxts.dev/docs/fromEntries | fromEntries}
  */
 
-function* entries<T extends Record<Key, any>>(
+function entries<T extends Map<any, any> | Set<any> | Record<Key, any>>(
   obj: T,
-): Generator<Entries<T, keyof T>, void> {
-  for (const k in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, k)) {
-      yield [k, obj[k]] as any;
+): EntriesResult<T>;
+
+function* entries(obj: any): Generator<any, void> {
+  if (obj instanceof Map) {
+    for (const entry of obj.entries()) {
+      yield entry;
+    }
+  } else if (obj instanceof Set) {
+    for (const v of obj) {
+      yield [v, v];
+    }
+  } else {
+    for (const k in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, k)) {
+        yield [k, obj[k]];
+      }
     }
   }
 }

--- a/test/Lazy/entries.spec.ts
+++ b/test/Lazy/entries.spec.ts
@@ -1,52 +1,106 @@
 import { entries } from "../../src";
 
 describe("entries", function () {
-  it("should return an iterator that iterates entries of the given object", function () {
-    const obj = {
-      a: 1,
-      b: "2",
-      c: true,
-      d: null,
-      e: undefined,
-    };
-    const iter = entries(obj);
-    expect(iter.next().value).toEqual(["a", 1]);
-    const res = [...iter];
-    expect(res).toEqual([
-      ["b", "2"],
-      ["c", true],
-      ["d", null],
-      ["e", undefined],
-    ]);
+  describe("Object support", function () {
+    it("should return an iterator that iterates entries of the given object", function () {
+      const obj = {
+        a: 1,
+        b: "2",
+        c: true,
+        d: null,
+        e: undefined,
+      };
+      const iter = entries(obj);
+      expect(iter.next().value).toEqual(["a", 1]);
+      const res = [...iter];
+      expect(res).toEqual([
+        ["b", "2"],
+        ["c", true],
+        ["d", null],
+        ["e", undefined],
+      ]);
+    });
+
+    it("should only deal with enumerable properties", function () {
+      const obj = { a: 1, b: 2, c: 3 };
+      Object.defineProperty(obj, "a", {
+        enumerable: false,
+      });
+      Object.defineProperty(obj, "c", {
+        enumerable: false,
+      });
+      const res = [...entries(obj)];
+      expect(res).toEqual([["b", 2]]);
+    });
+
+    it("should only deal with its own properties", function () {
+      class Parent {
+        a = 1;
+      }
+      class Child extends Parent {
+        b = 2;
+      }
+      const instance = new Child();
+      const proto = Object.getPrototypeOf(instance);
+      proto.__proto__.c = 3;
+      const res = [...entries(instance)];
+      expect((instance as any).c).toEqual(3);
+      expect(res).toEqual([
+        ["a", 1],
+        ["b", 2],
+      ]);
+    });
   });
 
-  it("should only deal with enumerable properties", function () {
-    const obj = { a: 1, b: 2, c: 3 };
-    Object.defineProperty(obj, "a", {
-      enumerable: false,
+  describe("Map support", function () {
+    it("should return entries from Map", function () {
+      const map = new Map([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ]);
+      const res = [...entries(map)];
+      expect(res).toEqual([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ]);
     });
-    Object.defineProperty(obj, "c", {
-      enumerable: false,
+
+    it("should handle empty Map", function () {
+      const map = new Map();
+      const res = [...entries(map)];
+      expect(res).toEqual([]);
     });
-    const res = [...entries(obj)];
-    expect(res).toEqual([["b", 2]]);
+
+    it("should preserve Map key types", function () {
+      const map = new Map<number, string>([
+        [1, "a"],
+        [2, "b"],
+      ]);
+      const res = [...entries(map)];
+      expect(res).toEqual([
+        [1, "a"],
+        [2, "b"],
+      ]);
+    });
   });
 
-  it("should only deal with its own properties", function () {
-    class Parent {
-      a = 1;
-    }
-    class Child extends Parent {
-      b = 2;
-    }
-    const instance = new Child();
-    const proto = Object.getPrototypeOf(instance);
-    proto.__proto__.c = 3;
-    const res = [...entries(instance)];
-    expect((instance as any).c).toEqual(3);
-    expect(res).toEqual([
-      ["a", 1],
-      ["b", 2],
-    ]);
+  describe("Set support", function () {
+    it("should return entries from Set as [value, value] pairs", function () {
+      const set = new Set([1, 2, 3]);
+      const res = [...entries(set)];
+      expect(res).toEqual([
+        [1, 1],
+        [2, 2],
+        [3, 3],
+      ]);
+    });
+
+    it("should handle empty Set", function () {
+      const set = new Set();
+      const res = [...entries(set)];
+      expect(res).toEqual([]);
+    });
   });
 });

--- a/type-check/Lazy/entries.test.ts
+++ b/type-check/Lazy/entries.test.ts
@@ -29,6 +29,26 @@ const res4 = entries(obj2);
 
 const res5 = entries({ 1: 1, a: "a", [Symbol("a")]: "a" });
 
+// Map type tests
+const map1 = new Map<string, number>([
+  ["a", 1],
+  ["b", 2],
+]);
+const resMap1 = entries(map1);
+
+const map2 = new Map<number, string>([
+  [1, "a"],
+  [2, "b"],
+]);
+const resMap2 = entries(map2);
+
+// Set type tests
+const set1 = new Set<number>([1, 2, 3]);
+const resSet1 = entries(set1);
+
+const set2 = new Set<string>(["a", "b"]);
+const resSet2 = entries(set2);
+
 checks([
   check<
     typeof res1,
@@ -68,4 +88,12 @@ checks([
     Generator<["1", number] | ["a", string], void>,
     Test.Pass
   >(),
+
+  // Map type checks
+  check<typeof resMap1, Generator<[string, number], void>, Test.Pass>(),
+  check<typeof resMap2, Generator<[number, string], void>, Test.Pass>(),
+
+  // Set type checks
+  check<typeof resSet1, Generator<[number, number], void>, Test.Pass>(),
+  check<typeof resSet2, Generator<[string, string], void>, Test.Pass>(),
 ]);


### PR DESCRIPTION
Fixed a bug where the entries function did not support Map and Set. While the same issue exists for keys and values, it is not addressed in this PR. The issue was caused by using a for...in loop, which does not work with Map and Set. When an iterable object is used in a for...in loop, it returns `undefined`.

## Reference
- Fixes #361 
- https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Set/entries