### PR TITLE
fix: remove any type in concurrent with functions

### DIFF
--- a/src/Lazy/append.ts
+++ b/src/Lazy/append.ts
@@ -1,7 +1,11 @@
 import { isAsyncIterable, isIterable, isPromise } from "../_internal/utils";
 import type Awaited from "../types/Awaited";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<A>(a: A, iterable: Iterable<A>) {
   yield* iterable;
@@ -40,13 +44,13 @@ function async<A>(
   a: Promise<A>,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  let iterator: AsyncIterator<A> | null = null;
+  let iterator: AsyncIterator<A, unknown, ConcurrentArg> | null = null;
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
 
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (iterator === null) {
         iterator = isConcurrent(_concurrent)
           ? asyncSequential(a, concurrent(_concurrent.length, iterable))

--- a/src/Lazy/chunk.ts
+++ b/src/Lazy/chunk.ts
@@ -7,7 +7,11 @@ import {
 import toArray from "../toArray";
 import type IterableInfer from "../types/IterableInfer";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 import take from "./take";
 
 function* sync<T>(size: number, iterable: Iterable<T>): IterableIterator<T[]> {
@@ -50,9 +54,9 @@ function async<T>(
   size: number,
   iterable: AsyncIterable<T>,
 ): AsyncIterableIterator<T[]> {
-  let _iterator: AsyncIterator<T[]>;
+  let _iterator: AsyncIterator<T[], unknown, ConcurrentArg>;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === undefined) {
         _iterator = isConcurrent(_concurrent)
           ? asyncSequential(size, concurrent(_concurrent.length, iterable))

--- a/src/Lazy/concat.ts
+++ b/src/Lazy/concat.ts
@@ -1,6 +1,7 @@
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import type IterableInfer from "../types/IterableInfer";
 import type ReturnConcatType from "../types/ReturnConcatType";
+import type { Concurrent, ConcurrentArg } from "./concurrent";
 
 function* sync<A>(a: Iterable<A>, b: Iterable<A>): IterableIterator<A> {
   yield* a;
@@ -12,14 +13,16 @@ function async<A>(
   b: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
   let leftDone = false;
-  const leftIterator = a[Symbol.asyncIterator]();
-  const rightIterator = b[Symbol.asyncIterator]();
+  const leftIterator: AsyncIterator<A, unknown, ConcurrentArg> =
+    a[Symbol.asyncIterator]();
+  const rightIterator: AsyncIterator<A, unknown, ConcurrentArg> =
+    b[Symbol.asyncIterator]();
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
 
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       const iterator = leftDone ? rightIterator : leftIterator;
       const { done, value } = await iterator.next(_concurrent);
       if (done) {

--- a/src/Lazy/concurrent.ts
+++ b/src/Lazy/concurrent.ts
@@ -18,6 +18,18 @@ export const isConcurrent = (concurrent: unknown): concurrent is Concurrent => {
 };
 
 /**
+ * The concurrency signal that lazy operators thread *backwards* through the
+ * iterator protocol's `next(value)` argument — i.e. the generator's `TNext`
+ * slot. A `Concurrent` instance turns on concurrent evaluation for the
+ * upstream chain; `undefined` means sequential.
+ *
+ * Use this as the third type argument of `AsyncIterator`/`AsyncIterableIterator`
+ * for the upstream iterator an operator pulls from, so the marker can be
+ * forwarded without `as any`.
+ */
+export type ConcurrentArg = Concurrent | undefined;
+
+/**
  * Concurrent is used to balance the load of multiple asynchronous requests.
  * The first argument receives a number that controls the number of loads, and the second argument is an AsyncIterable.
  * See {@link https://fxts.dev/api/toAsync | toAsync} to create an AsyncIterable .
@@ -93,7 +105,8 @@ function concurrent<A>(
     throw new TypeError("'iterable' must be type of AsyncIterable");
   }
 
-  const iterator = iterable[Symbol.asyncIterator]();
+  const iterator: AsyncIterator<A, unknown, ConcurrentArg> =
+    iterable[Symbol.asyncIterator]();
   const buffer: PromiseSettledResult<IteratorResult<A>>[] = [];
   let prev = Promise.resolve();
   let nextCallCount = 0;
@@ -130,9 +143,7 @@ function concurrent<A>(
       );
     } else {
       const nextItems = Promise.allSettled(
-        Array.from({ length }, () =>
-          iterator.next(Concurrent.of(length) as any),
-        ),
+        Array.from({ length }, () => iterator.next(Concurrent.of(length))),
       );
       pending = true;
       prev = prev

--- a/src/Lazy/cycle.ts
+++ b/src/Lazy/cycle.ts
@@ -1,7 +1,11 @@
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import type IterableInfer from "../types/IterableInfer";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<T>(iterable: Iterable<T>): IterableIterator<T> {
   const arr = [];
@@ -34,9 +38,9 @@ async function* asyncSequential<T>(
 }
 
 function async<T>(iterable: AsyncIterable<T>): AsyncIterableIterator<T> {
-  let _iterator: AsyncIterator<T>;
+  let _iterator: AsyncIterator<T, unknown, ConcurrentArg>;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === undefined) {
         _iterator = isConcurrent(_concurrent)
           ? asyncSequential(concurrent(_concurrent.length, iterable))

--- a/src/Lazy/differenceBy.ts
+++ b/src/Lazy/differenceBy.ts
@@ -3,7 +3,11 @@ import { isAsyncIterable, isIterable } from "../_internal/utils";
 import pipe from "../pipe";
 import pipe1 from "../pipe1";
 import toArray from "../toArray";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 import map from "./map";
 import reject from "./reject";
 import toAsync from "./toAsync";
@@ -42,9 +46,9 @@ function async<T>(
   iterable1: AsyncIterable<T>,
   iterable2: AsyncIterable<T>,
 ): AsyncIterableIterator<T> {
-  let _iterator: AsyncIterator<T>;
+  let _iterator: AsyncIterator<T, unknown, ConcurrentArg>;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === undefined) {
         _iterator = isConcurrent(_concurrent)
           ? asyncSequential(

--- a/src/Lazy/drop.ts
+++ b/src/Lazy/drop.ts
@@ -1,7 +1,11 @@
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import consume from "../consume";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<A>(length: number, iterable: Iterable<A>): IterableIterator<A> {
   const iterator = iterable[Symbol.iterator]();
@@ -29,13 +33,13 @@ function async<A>(
   length: number,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  let iterator: AsyncIterator<A>;
+  let iterator: AsyncIterator<A, unknown, ConcurrentArg>;
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
 
-    next(_concurrent: any) {
+    next(_concurrent?: Concurrent) {
       if (iterator === undefined) {
         iterator = isConcurrent(_concurrent)
           ? asyncSequential(length, concurrent(_concurrent.length, iterable))

--- a/src/Lazy/dropRight.ts
+++ b/src/Lazy/dropRight.ts
@@ -3,7 +3,11 @@ import isArray from "../isArray";
 import isString from "../isString";
 import toArray from "../toArray";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<T>(length: number, iterable: Iterable<T>) {
   const arr =
@@ -24,13 +28,13 @@ function async<A>(
   length: number,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  let iterator: AsyncIterator<A>;
+  let iterator: AsyncIterator<A, unknown, ConcurrentArg>;
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
 
-    next(_concurrent: any) {
+    next(_concurrent?: Concurrent) {
       if (iterator === undefined) {
         iterator = isConcurrent(_concurrent)
           ? asyncSequential(length, concurrent(_concurrent.length, iterable))

--- a/src/Lazy/dropUntil.ts
+++ b/src/Lazy/dropUntil.ts
@@ -2,7 +2,11 @@ import { AsyncFunctionException } from "../_internal/error";
 import { isAsyncIterable, isIterable, isPromise } from "../_internal/utils";
 import type IterableInfer from "../types/IterableInfer";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<A, B>(f: (a: A) => B, iterable: Iterable<A>) {
   const iterator = iterable[Symbol.iterator]();
@@ -46,13 +50,13 @@ function async<A, B>(
   f: (a: A) => B,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  let iterator: AsyncIterator<A>;
+  let iterator: AsyncIterator<A, unknown, ConcurrentArg>;
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
 
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (iterator === undefined) {
         iterator = isConcurrent(_concurrent)
           ? asyncSequential(f, concurrent(_concurrent.length, iterable))

--- a/src/Lazy/dropWhile.ts
+++ b/src/Lazy/dropWhile.ts
@@ -2,7 +2,11 @@ import { AsyncFunctionException } from "../_internal/error";
 import { isAsyncIterable, isIterable, isPromise } from "../_internal/utils";
 import type IterableInfer from "../types/IterableInfer";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<A, B>(f: (a: A) => B, iterable: Iterable<A>) {
   const iterator = iterable[Symbol.iterator]();
@@ -51,13 +55,13 @@ function async<A, B>(
   f: (a: A) => B,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  let iterator: AsyncIterator<A>;
+  let iterator: AsyncIterator<A, unknown, ConcurrentArg>;
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
 
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (iterator === undefined) {
         iterator = isConcurrent(_concurrent)
           ? asyncSequential(f, concurrent(_concurrent.length, iterable))

--- a/src/Lazy/filter.ts
+++ b/src/Lazy/filter.ts
@@ -5,7 +5,11 @@ import type IterableInfer from "../types/IterableInfer";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
 import type TruthyTypesOf from "../types/TrutyTypesOf";
 import type { Reject, Resolve } from "../types/Utils";
-import concurrent, { isConcurrent, type Concurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 async function* asyncSequential<A>(
   f: (a: A) => unknown,
@@ -19,7 +23,8 @@ async function* asyncSequential<A>(
 function asyncConcurrent<A>(
   iterable: AsyncIterable<[boolean, A]>,
 ): AsyncIterableIterator<A> {
-  const iterator = iterable[Symbol.asyncIterator]();
+  const iterator: AsyncIterator<[boolean, A], unknown, ConcurrentArg> =
+    iterable[Symbol.asyncIterator]();
   const settlementQueue: [Resolve<A>, Reject][] = [] as unknown as [
     Resolve<A>,
     Reject,
@@ -30,8 +35,8 @@ function asyncConcurrent<A>(
   let resolvedCount = 0;
   let prevItem = Promise.resolve();
 
-  function fillBuffer(concurrent: Concurrent) {
-    const nextItem = iterator.next(concurrent as any);
+  function fillBuffer(concurrent: ConcurrentArg) {
+    const nextItem = iterator.next(concurrent);
     prevItem = prevItem
       .then(() => nextItem)
       .then(({ done, value }) => {
@@ -72,7 +77,7 @@ function asyncConcurrent<A>(
     }
   }
 
-  function recur(concurrent: Concurrent) {
+  function recur(concurrent: ConcurrentArg) {
     if (finished || nextCallCount === resolvedCount) {
       return;
     } else if (buffer.length > 0) {
@@ -83,14 +88,14 @@ function asyncConcurrent<A>(
   }
 
   return {
-    async next(concurrent: any) {
+    async next(concurrent?: Concurrent) {
       nextCallCount++;
       if (finished) {
         return { done: true, value: undefined };
       }
       return new Promise((resolve, reject) => {
         settlementQueue.push([resolve, reject]);
-        recur(concurrent as Concurrent);
+        recur(concurrent);
       });
     },
     [Symbol.asyncIterator]() {
@@ -103,12 +108,13 @@ function toFilterIterator<A>(
   f: (a: A) => unknown,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<[boolean, A]> {
-  const iterator = iterable[Symbol.asyncIterator]();
+  const iterator: AsyncIterator<A, unknown, ConcurrentArg> =
+    iterable[Symbol.asyncIterator]();
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
-    async next(_concurrent) {
+    async next(_concurrent?: Concurrent) {
       const { done, value } = await iterator.next(_concurrent);
       if (done) {
         return {
@@ -133,9 +139,9 @@ function async<A>(
   f: (a: A) => unknown,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  let _iterator: AsyncIterator<A>;
+  let _iterator: AsyncIterator<A, unknown, ConcurrentArg>;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === undefined) {
         _iterator = isConcurrent(_concurrent)
           ? asyncConcurrent(

--- a/src/Lazy/flat.ts
+++ b/src/Lazy/flat.ts
@@ -6,7 +6,11 @@ import type IterableInfer from "../types/IterableInfer";
 import type { Reject, Resolve } from "../types/Utils";
 import append from "./append";
 import concat from "./concat";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 type ReturnFlatType<
   A extends Iterable<unknown> | AsyncIterable<unknown>,
@@ -185,9 +189,9 @@ function async<A>(
   iterable: AsyncIterable<A>,
   depth: number,
 ): AsyncIterableIterator<A> {
-  let _iterator: AsyncIterator<A> | null = null;
+  let _iterator: AsyncIterator<A, unknown, ConcurrentArg> | null = null;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === null) {
         _iterator = isConcurrent(_concurrent)
           ? asyncConcurrent(concurrent(_concurrent.length, iterable), depth)

--- a/src/Lazy/fork.ts
+++ b/src/Lazy/fork.ts
@@ -4,7 +4,7 @@ import type { LinkedListNode } from "../dataStructure/linkedList/linkedListNode"
 import isNil from "../isNil";
 import type IterableInfer from "../types/IterableInfer";
 import type { Reject, Resolve } from "../types/Utils";
-import type { Concurrent } from "./concurrent";
+import type { Concurrent, ConcurrentArg } from "./concurrent";
 
 type ReturnForkType<A extends Iterable<unknown> | AsyncIterable<unknown>> =
   A extends AsyncIterable<any>
@@ -115,7 +115,7 @@ function sync<T>(iterable: Iterable<T>) {
 
 type ForkAsyncItem = {
   queue: LinkedList<IteratorResult<Value>>;
-  next: (...args: any) => Promise<IteratorResult<Value, any>>;
+  next: AsyncIterator<Value, any, ConcurrentArg>["next"];
   done: boolean;
   error?: any;
   forks: Set<LinkedListNode<IteratorResult<Value>> | null>;
@@ -124,7 +124,8 @@ type ForkAsyncItem = {
 const forkAsyncMap = new WeakMap<AsyncIterator<Value>, ForkAsyncItem>();
 
 function async<T>(iterable: AsyncIterable<T>) {
-  const iterator = iterable[Symbol.asyncIterator]();
+  const iterator: AsyncIterator<T, unknown, ConcurrentArg> =
+    iterable[Symbol.asyncIterator]();
 
   const getNext = (forkItem: ForkAsyncItem) => {
     const settlementQueue: [Resolve<T>, Reject][] = [];

--- a/src/Lazy/intersectionBy.ts
+++ b/src/Lazy/intersectionBy.ts
@@ -3,7 +3,11 @@ import { isAsyncIterable, isIterable } from "../_internal/utils";
 import pipe from "../pipe";
 import pipe1 from "../pipe1";
 import toArray from "../toArray";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 import filter from "./filter";
 import map from "./map";
 import toAsync from "./toAsync";
@@ -42,9 +46,9 @@ function async<T>(
   iterable1: AsyncIterable<T>,
   iterable2: AsyncIterable<T>,
 ): AsyncIterableIterator<T> {
-  let _iterator: AsyncIterator<T>;
+  let _iterator: AsyncIterator<T, unknown, ConcurrentArg>;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === undefined) {
         _iterator = isConcurrent(_concurrent)
           ? asyncSequential(

--- a/src/Lazy/map.ts
+++ b/src/Lazy/map.ts
@@ -2,6 +2,7 @@ import { isAsyncIterable, isIterable } from "../_internal/utils";
 import type Awaited from "../types/Awaited";
 import type IterableInfer from "../types/IterableInfer";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import type { Concurrent, ConcurrentArg } from "./concurrent";
 
 function sync<A, B>(
   f: (a: A) => B,
@@ -34,10 +35,11 @@ function async<A, B>(
   f: (a: A) => B,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<B> {
-  const iterator = iterable[Symbol.asyncIterator]();
+  const iterator: AsyncIterator<A, unknown, ConcurrentArg> =
+    iterable[Symbol.asyncIterator]();
 
   return {
-    async next(_concurrent) {
+    async next(_concurrent?: Concurrent) {
       const { done, value } = await iterator.next(_concurrent);
       if (done) return { done, value } as IteratorReturnResult<void>;
       return {

--- a/src/Lazy/reverse.ts
+++ b/src/Lazy/reverse.ts
@@ -3,7 +3,11 @@ import isArray from "../isArray";
 import isString from "../isString";
 import toArray from "../toArray";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<T>(iterable: Iterable<T>) {
   const arr =
@@ -21,13 +25,13 @@ async function* asyncSequential<T>(iterable: AsyncIterable<T>) {
 }
 
 function async<T>(iterable: AsyncIterable<T>): AsyncIterableIterator<T> {
-  let iterator: AsyncIterator<T>;
+  let iterator: AsyncIterator<T, unknown, ConcurrentArg>;
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
 
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (iterator === undefined) {
         iterator = isConcurrent(_concurrent)
           ? asyncSequential(concurrent(_concurrent.length, iterable))

--- a/src/Lazy/scan.ts
+++ b/src/Lazy/scan.ts
@@ -5,7 +5,11 @@ import type Arrow from "../types/Arrow";
 import type Awaited from "../types/Awaited";
 import type IterableInfer from "../types/IterableInfer";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<A, B>(
   f: (a: B, b: A) => B,
@@ -34,9 +38,9 @@ function async<A, B>(
   acc: B | Promise<B>,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<B> {
-  let _iterator: AsyncIterator<B>;
+  let _iterator: AsyncIterator<B, unknown, ConcurrentArg>;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === undefined) {
         _iterator = isConcurrent(_concurrent)
           ? asyncSequential(f, acc, concurrent(_concurrent.length, iterable))
@@ -54,9 +58,9 @@ function asyncWithoutSeed<A, B>(
   f: (a: B, b: A) => B,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<B> {
-  let _iterator: AsyncIterator<B>;
+  let _iterator: AsyncIterator<B, unknown, ConcurrentArg>;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === undefined) {
         if (isConcurrent(_concurrent)) {
           const _iterable = concurrent(_concurrent.length, iterable);

--- a/src/Lazy/slice.ts
+++ b/src/Lazy/slice.ts
@@ -1,7 +1,11 @@
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import isNumber from "../isNumber";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<T>(
   start: number,
@@ -36,13 +40,13 @@ function async<T>(
   end: number,
   iterable: AsyncIterable<T>,
 ): AsyncIterableIterator<T> {
-  let iterator: AsyncIterator<T>;
+  let iterator: AsyncIterator<T, unknown, ConcurrentArg>;
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
 
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (iterator === undefined) {
         // prettier-ignore
         iterator = isConcurrent(_concurrent)

--- a/src/Lazy/split.ts
+++ b/src/Lazy/split.ts
@@ -1,6 +1,10 @@
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync(sep: string, iterable: Iterable<string>) {
   if (sep === "") {
@@ -53,9 +57,9 @@ function async(
   sep: string,
   iterable: AsyncIterable<string>,
 ): AsyncIterableIterator<string> {
-  let _iterator: AsyncIterator<string>;
+  let _iterator: AsyncIterator<string, unknown, ConcurrentArg>;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === undefined) {
         _iterator = isConcurrent(_concurrent)
           ? asyncSequential(sep, concurrent(_concurrent.length, iterable))

--- a/src/Lazy/take.ts
+++ b/src/Lazy/take.ts
@@ -1,6 +1,7 @@
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import type IterableInfer from "../types/IterableInfer";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
+import type { Concurrent, ConcurrentArg } from "./concurrent";
 
 function* sync<A>(length: number, iterable: Iterable<A>): IterableIterator<A> {
   const iterator = iterable[Symbol.iterator]();
@@ -14,12 +15,13 @@ function async<A>(
   length: number,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  const iterator = iterable[Symbol.asyncIterator]();
+  const iterator: AsyncIterator<A, unknown, ConcurrentArg> =
+    iterable[Symbol.asyncIterator]();
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
-    async next(_concurrent) {
+    async next(_concurrent?: Concurrent) {
       if (length-- < 1) return { done: true, value: undefined };
       return iterator.next(_concurrent);
     },

--- a/src/Lazy/takeRight.ts
+++ b/src/Lazy/takeRight.ts
@@ -4,7 +4,11 @@ import isString from "../isString";
 import toArray from "../toArray";
 import type IterableInfer from "../types/IterableInfer";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<A>(length: number, iterable: Iterable<A>): IterableIterator<A> {
   const arr =
@@ -29,12 +33,12 @@ function async<A>(
   length: number,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  let iterator: AsyncIterator<A>;
+  let iterator: AsyncIterator<A, unknown, ConcurrentArg>;
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
-    next(_concurrent: any) {
+    next(_concurrent?: Concurrent) {
       if (iterator === undefined) {
         iterator = isConcurrent(_concurrent)
           ? asyncSequential(length, concurrent(_concurrent.length, iterable))

--- a/src/Lazy/takeUntilInclusive.ts
+++ b/src/Lazy/takeUntilInclusive.ts
@@ -2,7 +2,11 @@ import { AsyncFunctionException } from "../_internal/error";
 import { isAsyncIterable, isIterable, isPromise } from "../_internal/utils";
 import type IterableInfer from "../types/IterableInfer";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<A, B>(f: (a: A) => B, iterable: Iterable<A>) {
   for (const item of iterable) {
@@ -23,13 +27,14 @@ function asyncSequential<A, B>(
   f: (a: A) => B,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  const iterator = iterable[Symbol.asyncIterator]();
+  const iterator: AsyncIterator<A, unknown, ConcurrentArg> =
+    iterable[Symbol.asyncIterator]();
   let end = false;
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
-    async next(_concurrent) {
+    async next(_concurrent?: Concurrent) {
       if (end) {
         return { done: true, value: undefined };
       }
@@ -57,9 +62,9 @@ function async<A, B>(
   f: (a: A) => B,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  let _iterator: AsyncIterator<A>;
+  let _iterator: AsyncIterator<A, unknown, ConcurrentArg>;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === undefined) {
         _iterator = isConcurrent(_concurrent)
           ? asyncSequential(f, concurrent(_concurrent.length, iterable))

--- a/src/Lazy/takeWhile.ts
+++ b/src/Lazy/takeWhile.ts
@@ -2,7 +2,11 @@ import { AsyncFunctionException } from "../_internal/error";
 import { isAsyncIterable, isIterable, isPromise } from "../_internal/utils";
 import type IterableInfer from "../types/IterableInfer";
 import type ReturnIterableIteratorType from "../types/ReturnIterableIteratorType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 
 function* sync<A, B>(f: (a: A) => B, iterable: Iterable<A>) {
   for (const item of iterable) {
@@ -22,13 +26,14 @@ function asyncSequential<A, B>(
   f: (a: A) => B,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  const iterator = iterable[Symbol.asyncIterator]();
+  const iterator: AsyncIterator<A, unknown, ConcurrentArg> =
+    iterable[Symbol.asyncIterator]();
   let end = false;
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
-    async next(_concurrent) {
+    async next(_concurrent?: Concurrent) {
       const { done, value } = await iterator.next(_concurrent);
       if (done || end) {
         return { done: true, value: undefined };
@@ -48,9 +53,9 @@ function async<A, B>(
   f: (a: A) => B,
   iterable: AsyncIterable<A>,
 ): AsyncIterableIterator<A> {
-  let _iterator: AsyncIterator<A>;
+  let _iterator: AsyncIterator<A, unknown, ConcurrentArg>;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === undefined) {
         _iterator = isConcurrent(_concurrent)
           ? asyncSequential(f, concurrent(_concurrent.length, iterable))

--- a/src/Lazy/transpose.ts
+++ b/src/Lazy/transpose.ts
@@ -7,6 +7,7 @@ import size from "../size";
 import toArray from "../toArray";
 import type ReturnZipType from "../types/ReturnZipType";
 import type { UniversalIterable } from "../types/Utils";
+import type { Concurrent, ConcurrentArg } from "./concurrent";
 import filter from "./filter";
 import map from "./map";
 import toAsync from "./toAsync";
@@ -29,13 +30,15 @@ function* sync(
 function async(
   iterable: Iterable<UniversalIterable>,
 ): AsyncIterableIterator<UniversalIterable> {
-  const iterators = toArray(map(toIterator, iterable as any));
+  const iterators: AsyncIterator<unknown, unknown, ConcurrentArg>[] = toArray(
+    map(toIterator, iterable as any),
+  );
 
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
-    async next(_concurrent) {
+    async next(_concurrent?: Concurrent) {
       const headIterators = await pipe(
         toAsync(iterators),
         map((iterator) => iterator.next(_concurrent)),

--- a/src/Lazy/zip.ts
+++ b/src/Lazy/zip.ts
@@ -4,6 +4,7 @@ import pipe from "../pipe";
 import toArray from "../toArray";
 import type ReturnZipType from "../types/ReturnZipType";
 import type { UniversalIterable } from "../types/Utils";
+import type { Concurrent, ConcurrentArg } from "./concurrent";
 import map from "./map";
 import range from "./range";
 import takeWhile from "./takeWhile";
@@ -27,13 +28,15 @@ function sync(
 function async(
   iterable: Iterable<UniversalIterable>,
 ): AsyncIterableIterator<UniversalIterable> {
-  const iterators = toArray(map(toIterator, iterable as any));
+  const iterators: AsyncIterator<unknown, unknown, ConcurrentArg>[] = toArray(
+    map(toIterator, iterable as any),
+  );
 
   return {
     [Symbol.asyncIterator]() {
       return this;
     },
-    async next(_concurrent) {
+    async next(_concurrent?: Concurrent) {
       const headIterators = await pipe(
         toAsync(iterators),
         map((it) => it.next(_concurrent)),

--- a/src/Lazy/zipWithIndex.ts
+++ b/src/Lazy/zipWithIndex.ts
@@ -1,6 +1,10 @@
 import { isAsyncIterable, isIterable } from "../_internal/utils";
 import type ReturnZipWithIndexType from "../types/ReturnZipWithIndexType";
-import concurrent, { isConcurrent } from "./concurrent";
+import concurrent, {
+  isConcurrent,
+  type Concurrent,
+  type ConcurrentArg,
+} from "./concurrent";
 import map from "./map";
 
 function _zipWithIndex<T extends Iterable<unknown> | AsyncIterable<unknown>>(
@@ -12,9 +16,9 @@ function _zipWithIndex<T extends Iterable<unknown> | AsyncIterable<unknown>>(
 }
 
 function async<T>(iterable: AsyncIterable<T>) {
-  let _iterator: AsyncIterator<[number, T]>;
+  let _iterator: AsyncIterator<[number, T], unknown, ConcurrentArg>;
   return {
-    async next(_concurrent: any) {
+    async next(_concurrent?: Concurrent) {
       if (_iterator === undefined) {
         _iterator = isConcurrent(_concurrent)
           ? _zipWithIndex(concurrent(_concurrent.length, iterable))


### PR DESCRIPTION
### Summary
  The concurrency marker that `concurrent(n)` threads back up the lazy chain travels through the iterator protocol's `next(value)` argument (the
  generator `TNext` slot). That channel was completely untyped — `Concurrent.of(length) as any` at the source and `_concurrent: any` in ~20
  operators. This PR types it properly with no runtime change.

  ### What changed
  - Added `export type ConcurrentArg = Concurrent | undefined` in `concurrent.ts` to document/name the channel.
  - Receiving side: `next(_concurrent: any)` → `next(_concurrent?: Concurrent)`.
  - Forwarding side: upstream iterators annotated as `AsyncIterator<A, unknown, ConcurrentArg>` so the marker forwards without a cast.
  - Removed the source cast (`Concurrent.of(length) as any` → `Concurrent.of(length)`) and the two casts in `filter` (`concurrent as any`,
  `recur(concurrent as Concurrent)`) by widening internal helpers to `ConcurrentArg`.
  - Same fix applied to `fork`'s internal `next` channel.

  Public return types (`IterableIterator` / `AsyncIterableIterator`) are unchanged — assignability is preserved via method bivariance, so this
  is type-only with zero behavior change.

  ### Why it's better than `any`
  `any` disabled checking on the marker and everything it touched. Now the compiler:
  - **enforces the `isConcurrent` guard** — `_concurrent.length` without narrowing is a compile error (`possibly 'undefined'`), preventing
  `undefined` deref;
  - **verifies the forwarding chain** — passing the marker to an iterator that can't receive it is now caught, instead of silently degrading
  concurrency to sequential;
  - **rejects wrong values** (e.g. `next(42)`) and **catches typos** on the marker;
  - restores autocomplete / hover / safe rename for the channel.

  ```ts
  // before: next(_concurrent: any)
  _concurrent.length            // ✅ compiles, may crash at runtime
  upstream.next(_concurrent)    // ✅ compiles, even if upstream can't receive it

  // after: next(_concurrent?: Concurrent)
  _concurrent.length            // ❌ TS18048: '_concurrent' is possibly 'undefined'
  if (isConcurrent(_concurrent)) _concurrent.length  // ✅ narrowed